### PR TITLE
fix issue #105

### DIFF
--- a/client/dplug/client/client.d
+++ b/client/dplug/client/client.d
@@ -24,7 +24,6 @@ import core.stdc.string;
 import core.stdc.stdio;
 
 import std.container;
-import std.regex;
 import std.json;
 
 import dplug.core.nogc;

--- a/client/dplug/client/client.d
+++ b/client/dplug/client/client.d
@@ -24,6 +24,8 @@ import core.stdc.string;
 import core.stdc.stdio;
 
 import std.container;
+import std.regex;
+import std.json;
 
 import dplug.core.nogc;
 import dplug.core.math;
@@ -102,6 +104,24 @@ struct PluginInfo
     /// Warning: receiving MIDI forces you to call `getNextMidiMessages`
     /// with the right number of `frames`, every buffer.
     bool receivesMIDI = false;
+}
+
+/// Should be called in Client class during compile time to parse
+/// PluginInfo from a supplied json file.
+enum PluginInfo parsePluginInfo(string json){
+  PluginInfo info;
+
+  JSONValue j = parseJSON(json);
+
+  info.vendorName = j["vendorName"].str;
+  info.vendorUniqueID = j["vendorUniqueID"].str;
+  info.pluginName = j["pluginName"].str;
+  info.pluginUniqueID = j["pluginUniqueID"].str;
+  info.hasGUI = true;
+  if(j["isSynth"].toString == "true") info.isSynth = true;
+  if(j["receivesMIDI"].toString == "true") info.receivesMIDI = true;
+
+  return info;
 }
 
 /// This allows to write things life tempo-synced LFO.
@@ -522,7 +542,7 @@ nothrow:
     {
 
         if (_maxFramesInProcess == 0)
-        {            
+        {
             processAudio(inputs, outputs, frames, timeInfo);
         }
         else
@@ -567,7 +587,7 @@ nothrow:
         if (_maxFramesInProcess != 0 && _maxFramesInProcess < maxFrames)
             maxFrames = _maxFramesInProcess;
 
-        // Calls the reset virtual call        
+        // Calls the reset virtual call
         reset(sampleRate, maxFrames, numInputs, numOutputs);
     }
 
@@ -622,7 +642,7 @@ private:
     int _maxFramesInProcess;
 
     // Container for awaiting MIDI messages.
-    MidiQueue _midiQueue; 
+    MidiQueue _midiQueue;
 
     final void createGraphicsLazily() nothrow @nogc
     {

--- a/examples/distort/distort.d
+++ b/examples/distort/distort.d
@@ -45,20 +45,12 @@ nothrow:
     {
     }
 
-    // The information that is duplicated here and in plugin.json should be the same
+    // Plugin info is parsed from plugin.json here at compile time
+    static PluginInfo pluginInfo = parsePluginInfo(import("plugin.json"));
+
     override PluginInfo buildPluginInfo()
     {
-        // change all of these!
-        PluginInfo info;
-        info.vendorName = "Witty Audio";
-        info.vendorUniqueID = "Wity";
-        info.pluginName = "Destructatorizer";
-        info.pluginUniqueID = "WiDi";
-        info.pluginVersion = PluginVersion(1, 0, 0);
-        info.isSynth = false;
-        info.receivesMIDI = false;
-        info.hasGUI = true;
-        return info;
+        return pluginInfo;
     }
 
     // This is an optional overload, default is zero parameter.
@@ -122,7 +114,7 @@ nothrow:
         }
     }
 
-    override void processAudio(const(float*)[] inputs, float*[]outputs, int frames, 
+    override void processAudio(const(float*)[] inputs, float*[]outputs, int frames,
                                TimeInfo info) nothrow @nogc
     {
         assert(frames <= 128); // guaranteed by audio buffer splitting
@@ -351,4 +343,3 @@ nothrow:
         }
     }
 }
-

--- a/examples/distort/dub.json
+++ b/examples/distort/dub.json
@@ -4,7 +4,7 @@
     "license": "public domain",
     "importPaths": [ "." ],
     "sourcePaths": [ "." ],
-    "stringImportPaths": ["gfx", "fonts"],
+    "stringImportPaths": ["gfx", "fonts", "."],
 
     "copyright": "none",
 


### PR DESCRIPTION
I wrote a function called `parsePluginInfo` in `client.d` which uses `std.json` to parse `plugin.json`.  The function is called at compile time to generate the `pluginInfo`.

Using static instead of enum worked to force the function to use CTFE.