### PR TITLE
Make it possible to remove UI Element from UI

### DIFF
--- a/gui/dplug/gui/element.d
+++ b/gui/dplug/gui/element.d
@@ -151,6 +151,17 @@ nothrow:
         _children.pushBack(element); 
     }
 
+    // Removes a child but does not destroy it.
+    // Useful for creating dynamic UI's
+    final void removeChild(UIElement element)
+    {
+        int index= _children.indexOf(element);
+        if(index >= 0)
+        {
+            _children.removeAndReplaceByLastElement(index);
+        }
+    }
+
     // This function is meant to be overriden.
     // Happens _before_ checking for children collisions.
     bool onMouseClick(int x, int y, int button, bool isDoubleClick, MouseState mstate)


### PR DESCRIPTION
This is a simple solution for #170.  A child element can be removed from the UI using `removeChild(UIElement element)` and can be added back as needed using `addChild(UIElement element)`