### PR TITLE
fix #176 - x11window causing seg fault

### DIFF
--- a/window/dplug/window/x11window.d
+++ b/window/dplug/window/x11window.d
@@ -224,8 +224,8 @@ nothrow:
     override uint getTimeMs()
     {
         static uint perform() {
-            import std.datetime : Clock;
-            return cast(uint)(Clock.currTime.stdTime / 100000);
+            import core.stdc.time;
+            return cast(uint)ctime(null);
         }
 
         return assumeNothrowNoGC(&perform)();


### PR DESCRIPTION
x11window now uses `ctime` to get current system time instead of using phobos which uses the GC and results in a seg fault.