### PR TITLE
VST plugins now open and render correctly on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ tools/stress-plugin/stress-plugin
 tools/wav-compare/wav-compare
 builds
 repro*.sh
+*.sh

--- a/window/dplug/window/window.d
+++ b/window/dplug/window/window.d
@@ -216,7 +216,7 @@ IWindow createWindow(void* parentInfo, void* controlInfo, IWindowListener listen
         if (backend == WindowBackend.x11)
         {
             import dplug.window.x11window;
-            return mallocNew!X11Window(parentInfo, listener, width, height);
+            return mallocNew!X11Window(null, listener, width, height);
         }
         else
             return null;


### PR DESCRIPTION
X11 Window now runs a separate thread to check for events and then redraws the UI
Plugins on linux also open their own window now.  This works since the plugin also creates it's own connection to X.  Ideally we shouldnt have to do this, but casting the parentWindow to an X Window isn't working properly.

One thing to note is that the CPU use seems to be very high.  I'm sure there are many optimizations to be made.  But for now I am happy to see a plugin actually run and to mouse events.