### PR TITLE
add flat-widgets subpackage

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -142,6 +142,19 @@
             }
         },
         {
+            "name": "flat-widgets",
+            "sourcePaths": [ "flatwidgets/dplug/flatwidgets" ],
+            "importPaths": [ "flatwidgets" ],
+
+            "dependencies": {
+                "dplug:core": "*",
+                "dplug:graphics": "*",
+                "dplug:window": "*",
+                "dplug:client": "*",
+                "dplug:gui": "*",
+            }
+        },
+        {
             "name": "cocoa",
             "sourcePaths": [ "cocoa/derelict/cocoa" ],
             "importPaths": [ "cocoa" ],

--- a/flatwidgets/dplug/flatwidgets/flatknob.d
+++ b/flatwidgets/dplug/flatwidgets/flatknob.d
@@ -1,0 +1,297 @@
+/**
+* Copyright: Copyright Auburn Sounds 2015 and later.
+* Copyright: Copyright Cut Through Recordings 2017
+* License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+* Authors:   Guillaume Piolat, Ethan Reker
+*/
+module dplug.flatwidgets.flatknob;
+
+import std.math;
+import std.algorithm.comparison;
+
+import dplug.core.math;
+import dplug.graphics.drawex;
+
+import dplug.gui.element;
+
+import dplug.client.params;
+
+/**
+* 
+*/
+class UIFilmstripKnob : UIElement, IParameterListener
+{
+public:
+nothrow:
+@nogc:
+
+    // This will change to 1.0f at one point for consistency, so better express your knob
+    // sensivity with that.
+    enum defaultSensivity = 0.25f;
+
+    float animationTimeConstant = 40.0f;
+
+    this(UIContext context, FloatParameter param, OwnedImage!RGBA mipmap, int numFrames, float sensitivity = 0.25)
+    {
+        super(context);
+        _param = param;
+        _sensitivity = sensitivity;
+        _filmstrip = mipmap;
+        _numFrames = numFrames;
+        knobWidth = _filmstrip.w;
+		knobHeight = _filmstrip.h / _numFrames;
+
+        _disabled = false;
+
+    }
+
+    ~this()
+    {
+        _param.removeListener(this);
+    }
+
+    /// Returns: sensivity.
+    float sensivity()
+    {
+        return _sensitivity;
+    }
+
+    /// Sets sensivity.
+    float sensivity(float sensitivity)
+    {
+        return _sensitivity = sensitivity;
+    }
+
+    void disable()
+    {
+        _disabled = true;
+    }
+
+    override void onDraw(ImageRef!RGBA diffuseMap, ImageRef!L16 depthMap, ImageRef!RGBA materialMap, box2i[] dirtyRects) nothrow @nogc
+	{
+		setCurrentImage();
+		auto _currentImage = _filmstrip.crop(box2i(_imageX1, _imageY1, _imageX2, _imageY2));
+		foreach(dirtyRect; dirtyRects){
+
+			float radius = getRadius();
+			vec2f center = getCenter();
+
+			auto croppedDiffuseIn = _currentImage.crop(dirtyRect);
+			auto croppedDiffuseOut = diffuseMap.crop(dirtyRect);
+
+			int w = dirtyRect.width;
+			int h = dirtyRect.height;
+
+			for(int j = 0; j < h; ++j){
+
+				RGBA[] input = croppedDiffuseIn.scanline(j);
+				RGBA[] output = croppedDiffuseOut.scanline(j);
+
+
+				for(int i = 0; i < w; ++i){
+					ubyte alpha = input[i].a;
+
+					RGBA color = RGBA.op!q{.blend(a, b, c)} (input[i], output[i], alpha);
+					output[i] = color;
+				}
+			}
+
+		}
+	}
+
+	float distance(float x1, float x2, float y1, float y2)
+	{
+		return sqrt((x2-x1)*(x2-x1) + (y2-y1)*(y2-y1));
+	}
+
+	void setCurrentImage()
+	{
+        float value = _param.getNormalized();
+		currentFrame = cast(int)(round(value * (_numFrames - 1)));
+
+		if(currentFrame < 0) currentFrame = 0;
+
+		_imageX1 = 0;
+		_imageY1 = (_filmstrip.h / _numFrames) * currentFrame;
+
+		_imageX2 = _filmstrip.w;
+		_imageY2 = _imageY1 + (_filmstrip.h / _numFrames);
+
+	}
+
+    override bool onMouseClick(int x, int y, int button, bool isDoubleClick, MouseState mstate)
+    {
+        if (!containsPoint(x, y))
+            return false;
+
+        // double-click => set to default
+        if (isDoubleClick)
+        {
+			_param.beginParamEdit();
+            _param.setFromGUI(_param.defaultValue());
+			_param.endParamEdit();
+        }
+
+        return true; // to initiate dragging
+    }
+
+	//void setFilmstripImage(OwnedImage!RGBA image, int numFrames)
+	//{
+		//_filmstrip = image;
+	//}
+
+    // Called when mouse drag this Element.
+    override void onMouseDrag(int x, int y, int dx, int dy, MouseState mstate)
+    {
+        if(!_disabled)
+        {
+            float displacementInHeight = cast(float)(dy) / _position.height;
+
+            float modifier = 1.0f;
+            if (mstate.shiftPressed || mstate.ctrlPressed)
+                modifier *= 0.1f;
+
+            double oldParamValue = _param.getNormalized();
+
+            double newParamValue = oldParamValue - displacementInHeight * modifier * _sensitivity;
+
+            if (y > _mousePosOnLast0Cross)
+                return;
+            if (y < _mousePosOnLast1Cross)
+                return;
+
+            if (newParamValue <= 0 && oldParamValue > 0)
+                _mousePosOnLast0Cross = y;
+
+            if (newParamValue >= 1 && oldParamValue < 1)
+                _mousePosOnLast1Cross = y;
+
+            if (newParamValue < 0)
+                newParamValue = 0;
+            if (newParamValue > 1)
+                newParamValue = 1;
+
+            if (newParamValue > 0)
+                _mousePosOnLast0Cross = float.infinity;
+
+            if (newParamValue < 1)
+                _mousePosOnLast1Cross = -float.infinity;
+
+            if (newParamValue != oldParamValue)
+                _param.setFromGUINormalized(newParamValue);
+            setDirtyWhole();
+        }
+    }
+
+    // For lazy updates
+    override void onBeginDrag()
+    {
+        _param.beginParamEdit();
+        setDirtyWhole();
+    }
+
+    override void onStopDrag()
+    {
+        _param.endParamEdit();
+        clearCrosspoints();
+        setDirtyWhole();
+    }
+
+    override void onMouseMove(int x, int y, int dx, int dy, MouseState mstate)
+    {
+        //_shouldBeHighlighted = containsPoint(x, y);
+    }
+
+    override void onMouseExit()
+    {
+        //_shouldBeHighlighted = false;
+    }
+
+    override void onParameterChanged(Parameter sender) nothrow @nogc
+    {
+        setDirtyWhole();
+    }
+
+    override void onBeginParameterEdit(Parameter sender)
+    {
+    }
+
+    override void onEndParameterEdit(Parameter sender)
+    {
+    }
+
+protected:
+
+    /// The parameter this knob is linked with.
+    FloatParameter _param;
+
+    OwnedImage!RGBA _filmstrip;
+    OwnedImage!RGBA _faderFilmstrip;
+    OwnedImage!RGBA _knobGreenFilmstrip;
+    ImageRef!RGBA _currentImage;
+	int _numFrames;
+	int _imageX1, _imageX2, _imageY1, _imageY2;
+	int currentFrame;
+
+	public int knobWidth;
+	public int knobHeight;
+
+    float _pushedAnimation;
+
+    /// Sensivity: given a mouse movement in 100th of the height of the knob,
+    /// how much should the normalized parameter change.
+    float _sensitivity;
+
+    bool _shouldBeHighlighted = false;
+
+    float _mousePosOnLast0Cross;
+    float _mousePosOnLast1Cross;
+
+    bool _disabled;
+
+    void clearCrosspoints() nothrow @nogc
+    {
+        _mousePosOnLast0Cross = float.infinity;
+        _mousePosOnLast1Cross = -float.infinity;
+    }
+
+    final bool containsPoint(int x, int y) nothrow @nogc
+    {
+        vec2f center = getCenter();
+        return vec2f(x, y).distanceTo(center) < getRadius();
+    }
+
+    /// Returns: largest square centered in _position
+    final box2i getSubsquare() pure const nothrow @nogc
+    {
+        // We'll draw entirely in the largest centered square in _position.
+        box2i subSquare;
+        if (_position.width > _position.height)
+        {
+            int offset = (_position.width - _position.height) / 2;
+            int minX = offset;
+            subSquare = box2i(minX, 0, minX + _position.height, _position.height);
+        }
+        else
+        {
+            int offset = (_position.height - _position.width) / 2;
+            int minY = offset;
+            subSquare = box2i(0, minY, _position.width, minY + _position.width);
+        }
+        return subSquare;
+    }
+
+    final float getRadius() pure const nothrow @nogc
+    {
+        return getSubsquare().width * 0.5f;
+
+    }
+
+    final vec2f getCenter() pure const nothrow @nogc
+    {
+        box2i subSquare = getSubsquare();
+        float centerx = (subSquare.min.x + subSquare.max.x - 1) * 0.5f;
+        float centery = (subSquare.min.y + subSquare.max.y - 1) * 0.5f;
+        return vec2f(centerx, centery);
+    }
+}

--- a/flatwidgets/dplug/flatwidgets/flatslider.d
+++ b/flatwidgets/dplug/flatwidgets/flatslider.d
@@ -1,0 +1,269 @@
+/**
+* Copyright: Copyright Auburn Sounds 2015 and later.
+* Copyright: Copyright Cut Through Recordings 2017
+* License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+* Authors:   Guillaume Piolat, Ethan Reker
+*/
+
+module dplug.flatwidgets.flatslider;
+
+import std.math;
+import std.algorithm.comparison;
+
+import dplug.core.math;
+import dplug.graphics.drawex;
+import dplug.gui.bufferedelement;
+import dplug.client.params;
+
+class UIFilmstripSlider : UIElement, IParameterListener
+{
+public:
+nothrow:
+@nogc:
+
+    this(UIContext context, FloatParameter param, OwnedImage!RGBA mipmap, int numFrames, float sensitivity = 0.25)
+    {
+        super(context);
+        _param = param;
+        _sensivity = sensitivity;
+        _filmstrip = mipmap;
+        _numFrames = numFrames;
+        knobWidth = _filmstrip.w;
+		knobHeight = _filmstrip.h / _numFrames;
+        _disabled = false;
+        _hidden = false;
+    }
+
+    ~this()
+    {
+        _param.removeListener(this);
+    }
+
+    /// Returns: sensivity.
+    float sensivity()
+    {
+        return _sensivity;
+    }
+
+    /// Sets sensivity.
+    float sensivity(float sensivity)
+    {
+        return _sensivity = sensivity;
+    }
+
+    override void onAnimate(double dt, double time) nothrow @nogc
+    {
+        float target = isDragged() ? 1 : 0;
+        float newAnimation = lerp(_pushedAnimation, target, 1.0 - exp(-dt * 30));
+        if (abs(newAnimation - _pushedAnimation) > 0.001f)
+        {
+            _pushedAnimation = newAnimation;
+            setDirtyWhole();
+        }
+    }
+
+    override void onDraw(ImageRef!RGBA diffuseMap, ImageRef!L16 depthMap, ImageRef!RGBA materialMap, box2i[] dirtyRects) nothrow @nogc
+	{
+        setCurrentImage();
+        auto _currentImage = _filmstrip.crop(box2i(_imageX1, _imageY1, _imageX2, _imageY2));
+        foreach(dirtyRect; dirtyRects){
+
+            auto croppedDiffuseIn = _currentImage.crop(dirtyRect);
+            auto croppedDiffuseOut = diffuseMap.crop(dirtyRect);
+
+            int w = dirtyRect.width;
+            int h = dirtyRect.height;
+
+            for(int j = 0; j < h; ++j){
+
+                RGBA[] input = croppedDiffuseIn.scanline(j);
+                RGBA[] output = croppedDiffuseOut.scanline(j);
+
+
+                for(int i = 0; i < w; ++i){
+                    ubyte alpha = input[i].a;
+
+                    RGBA color = RGBA.op!q{.blend(a, b, c)} (input[i], output[i], alpha);
+                    output[i] = color;
+                }
+            }
+
+        }
+	}
+
+    void setCurrentImage()
+	{
+        float value = _param.getNormalized();
+		currentFrame = cast(int)(round(value * (_numFrames - 1)));
+
+		if(currentFrame < 0) currentFrame = 0;
+		if(currentFrame > 59) currentFrame = 59;
+
+		_imageX1 = 0;
+		_imageY1 = (_filmstrip.h / _numFrames) * currentFrame;
+
+		_imageX2 = _filmstrip.w;
+		_imageY2 = _imageY1 + (_filmstrip.h / _numFrames);
+
+	}
+
+    override bool onMouseClick(int x, int y, int button, bool isDoubleClick, MouseState mstate)
+    {
+        // double-click => set to default
+        if (isDoubleClick)
+        {
+			_param.beginParamEdit();
+            if (auto p = cast(FloatParameter)_param)
+                p.setFromGUI(p.defaultValue());
+            else if (auto p = cast(IntegerParameter)_param)
+                p.setFromGUI(p.defaultValue());
+            else
+                assert(false); // only integer and float parameters supported
+			_param.endParamEdit();
+        }
+
+        return true; // to initiate dragging
+    }
+
+    // Called when mouse drag this Element.
+    override void onMouseDrag(int x, int y, int dx, int dy, MouseState mstate)
+    {
+        // FUTURE: replace by actual trail height instead of total height
+        if(!_disabled)
+        {
+            float displacementInHeight = cast(float)(dy) / _position.height; 
+
+            float modifier = 1.0f;
+            if (mstate.shiftPressed || mstate.ctrlPressed)
+                modifier *= 0.1f;
+
+            double oldParamValue = _param.getNormalized() + _draggingDebt;
+            double newParamValue = oldParamValue - displacementInHeight * modifier * _sensivity;
+
+            if (y > _mousePosOnLast0Cross)
+                return;
+            if (y < _mousePosOnLast1Cross)
+                return;
+
+            if (newParamValue <= 0 && oldParamValue > 0)
+                _mousePosOnLast0Cross = y;
+
+            if (newParamValue >= 1 && oldParamValue < 1)
+                _mousePosOnLast1Cross = y;
+
+            if (newParamValue < 0)
+                newParamValue = 0;
+            if (newParamValue > 1)
+                newParamValue = 1;
+
+            if (newParamValue > 0)
+                _mousePosOnLast0Cross = float.infinity;
+
+            if (newParamValue < 1)
+                _mousePosOnLast1Cross = -float.infinity;
+
+            if (newParamValue != oldParamValue)
+            {
+                if (auto p = cast(FloatParameter)_param)
+                {
+                    p.setFromGUINormalized(newParamValue);
+                }
+                /*else if (auto p = cast(IntegerParameter)_param)
+                {
+                    p.setFromGUINormalized(newParamValue);
+                    _draggingDebt = newParamValue - p.getNormalized();
+                }*/
+                else
+                    assert(false); // only integer and float parameters supported
+            }
+            setDirtyWhole();
+        }
+    }
+
+    // For lazy updates
+    override void onBeginDrag()
+    {
+        _param.beginParamEdit();
+        setDirtyWhole();
+    }
+
+    override void onStopDrag()
+    {
+        _param.endParamEdit();
+        setDirtyWhole();
+        _draggingDebt = 0.0f;
+    }
+
+    override void onMouseEnter()
+    {
+    }
+
+    override void onMouseExit()
+    {
+    }
+
+    override void onParameterChanged(Parameter sender)
+    {
+        setDirtyWhole();
+    }
+
+    override void onBeginParameterEdit(Parameter sender)
+    {
+    }
+
+    override void onEndParameterEdit(Parameter sender)
+    {
+    }
+
+    void disable()
+    {
+        _disabled = true;
+    }
+
+    void hide()
+    {
+        _hidden = true;
+        _disabled = true;
+    }
+
+    void unhide()
+    {
+        _hidden = false;
+        _disabled = false;
+    }
+
+protected:
+
+    /// The parameter this switch is linked with.
+    Parameter _param;
+
+    OwnedImage!RGBA _filmstrip;
+	int _numFrames;
+	int _imageX1, _imageX2, _imageY1, _imageY2;
+	int currentFrame;
+
+	public int knobWidth;
+	public int knobHeight;
+
+    /// Sensivity: given a mouse movement in 100th of the height of the knob,
+    /// how much should the normalized parameter change.
+    float _sensivity;
+
+    float  _pushedAnimation;
+
+    float _mousePosOnLast0Cross;
+    float _mousePosOnLast1Cross;
+
+    // Exists because small mouse drags for integer parameters may not 
+    // lead to a parameter value change, hence a need to accumulate those drags.
+    float _draggingDebt = 0.0f;
+
+    bool _disabled;
+    bool _hidden;
+
+    void clearCrosspoints()
+    {
+        _mousePosOnLast0Cross = float.infinity;
+        _mousePosOnLast1Cross = -float.infinity;
+    }
+}

--- a/flatwidgets/dplug/flatwidgets/flatslider.d
+++ b/flatwidgets/dplug/flatwidgets/flatslider.d
@@ -28,10 +28,9 @@ nothrow:
         _sensivity = sensitivity;
         _filmstrip = mipmap;
         _numFrames = numFrames;
-        knobWidth = _filmstrip.w;
-		knobHeight = _filmstrip.h / _numFrames;
+        _knobWidth = _filmstrip.w;
+        _knobHeight = _filmstrip.h / _numFrames;
         _disabled = false;
-        _hidden = false;
     }
 
     ~this()
@@ -63,7 +62,7 @@ nothrow:
     }
 
     override void onDraw(ImageRef!RGBA diffuseMap, ImageRef!L16 depthMap, ImageRef!RGBA materialMap, box2i[] dirtyRects) nothrow @nogc
-	{
+    {
         setCurrentImage();
         auto _currentImage = _filmstrip.crop(box2i(_imageX1, _imageY1, _imageX2, _imageY2));
         foreach(dirtyRect; dirtyRects){
@@ -89,37 +88,37 @@ nothrow:
             }
 
         }
-	}
+    }
 
     void setCurrentImage()
-	{
+    {
         float value = _param.getNormalized();
-		currentFrame = cast(int)(round(value * (_numFrames - 1)));
+        currentFrame = cast(int)(round(value * (_numFrames - 1)));
 
-		if(currentFrame < 0) currentFrame = 0;
-		if(currentFrame > 59) currentFrame = 59;
+        if(currentFrame < 0) currentFrame = 0;
+        if(currentFrame > 59) currentFrame = 59;
 
-		_imageX1 = 0;
-		_imageY1 = (_filmstrip.h / _numFrames) * currentFrame;
+        _imageX1 = 0;
+        _imageY1 = (_filmstrip.h / _numFrames) * currentFrame;
 
-		_imageX2 = _filmstrip.w;
-		_imageY2 = _imageY1 + (_filmstrip.h / _numFrames);
+        _imageX2 = _filmstrip.w;
+        _imageY2 = _imageY1 + (_filmstrip.h / _numFrames);
 
-	}
+    }
 
     override bool onMouseClick(int x, int y, int button, bool isDoubleClick, MouseState mstate)
     {
         // double-click => set to default
         if (isDoubleClick)
         {
-			_param.beginParamEdit();
+            _param.beginParamEdit();
             if (auto p = cast(FloatParameter)_param)
                 p.setFromGUI(p.defaultValue());
             else if (auto p = cast(IntegerParameter)_param)
                 p.setFromGUI(p.defaultValue());
             else
                 assert(false); // only integer and float parameters supported
-			_param.endParamEdit();
+            _param.endParamEdit();
         }
 
         return true; // to initiate dragging
@@ -220,30 +219,18 @@ nothrow:
         _disabled = true;
     }
 
-    void hide()
-    {
-        _hidden = true;
-        _disabled = true;
-    }
-
-    void unhide()
-    {
-        _hidden = false;
-        _disabled = false;
-    }
-
 protected:
 
     /// The parameter this switch is linked with.
     Parameter _param;
 
     OwnedImage!RGBA _filmstrip;
-	int _numFrames;
-	int _imageX1, _imageX2, _imageY1, _imageY2;
-	int currentFrame;
+    int _numFrames;
+    int _imageX1, _imageX2, _imageY1, _imageY2;
+    int currentFrame;
 
-	public int knobWidth;
-	public int knobHeight;
+    int _knobWidth;
+    int _knobHeight;
 
     /// Sensivity: given a mouse movement in 100th of the height of the knob,
     /// how much should the normalized parameter change.
@@ -259,7 +246,6 @@ protected:
     float _draggingDebt = 0.0f;
 
     bool _disabled;
-    bool _hidden;
 
     void clearCrosspoints()
     {

--- a/flatwidgets/dplug/flatwidgets/flatswitch.d
+++ b/flatwidgets/dplug/flatwidgets/flatswitch.d
@@ -1,0 +1,165 @@
+/**
+* Copyright: Copyright Cut Through Recordings 2017
+* License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+* Authors:   Ethan Reker
+*/
+module dplug.flatwidgets.flatswitch;
+
+import std.math;
+import dplug.core.math;
+import dplug.graphics.drawex;
+import dplug.gui.element;
+import dplug.client.params;
+
+class UIImageSwitch : UIElement, IParameterListener
+{
+public:
+nothrow:
+@nogc:
+
+    enum Orientation
+    {
+        vertical,
+        horizontal
+    }
+
+    float animationTimeConstant = 40.0f;
+
+    int _width;
+    int _height;
+
+    Orientation orientation = Orientation.vertical;
+
+    this(UIContext context, BoolParameter param, OwnedImage!RGBA onImage, OwnedImage!RGBA offImage)
+    {
+        super(context);
+        _param = param;
+        _param.addListener(this);
+        _animation = 0.0f;
+
+        _onImage = onImage;
+        _offImage = offImage;
+        assert(_onImage.h == _offImage.h);
+        assert(_onImage.w == _offImage.w);
+        _width = _onImage.w;
+        _height = _onImage.h;
+
+    }
+
+    ~this()
+    {
+        _param.removeListener(this);
+    }
+
+    bool getState(){
+      return unsafeObjectCast!BoolParameter(_param).valueAtomic();
+    }
+
+    override void onAnimate(double dt, double time) nothrow @nogc
+    {
+        float target = _param.value() ? 1 : 0;
+
+        float newAnimation = lerp(_animation, target, 1.0 - exp(-dt * animationTimeConstant));
+
+        if (abs(newAnimation - _animation) > 0.001f)
+        {
+            _animation = newAnimation;
+            setDirtyWhole();
+        }
+    }
+
+    override void onDraw(ImageRef!RGBA diffuseMap, ImageRef!L16 depthMap, ImageRef!RGBA materialMap, box2i[] dirtyRects) nothrow @nogc
+    {
+  		auto _currentImage = getState() ? _onImage : _offImage;
+  		foreach(dirtyRect; dirtyRects){
+
+  			//float radius = getRadius();
+  			//vec2f center = getCenter();
+
+  			auto croppedDiffuseIn = _currentImage.crop(dirtyRect);
+  			auto croppedDiffuseOut = diffuseMap.crop(dirtyRect);
+
+  			int w = dirtyRect.width;
+  			int h = dirtyRect.height;
+
+  			for(int j = 0; j < h; ++j){
+
+  				RGBA[] input = croppedDiffuseIn.scanline(j);
+  				RGBA[] output = croppedDiffuseOut.scanline(j);
+
+
+  				for(int i = 0; i < w; ++i){
+  					ubyte alpha = input[i].a;
+
+  					RGBA color = RGBA.op!q{.blend(a, b, c)} (input[i], output[i], alpha);
+  					output[i] = color;
+  				}
+  			}
+
+  		}
+    }
+
+    override bool onMouseClick(int x, int y, int button, bool isDoubleClick, MouseState mstate)
+    {
+        // double-click => set to default
+        _param.beginParamEdit();
+        _param.setFromGUI(!_param.value());
+        _param.endParamEdit();
+        return true;
+    }
+
+    override void onMouseEnter()
+    {
+        setDirtyWhole();
+    }
+
+	override void onMouseMove(int x, int y, int dx, int dy, MouseState mstate)
+    {
+        //_shouldBeHighlighted = containsPoint(x, y);
+    }
+
+    override void onMouseExit()
+    {
+        setDirtyWhole();
+    }
+
+    override void onBeginDrag()
+    {
+
+    }
+
+    override void onStopDrag()
+    {
+
+    }
+    
+    override void onMouseDrag(int x, int y, int dx, int dy, MouseState mstate)
+    {
+
+        
+    }
+
+    override void onParameterChanged(Parameter sender) nothrow @nogc
+    {
+        setDirtyWhole();
+    }
+
+    override void onBeginParameterEdit(Parameter sender)
+    {
+    }
+
+    override void onEndParameterEdit(Parameter sender)
+    {
+    }
+
+protected:
+
+    /// The parameter this switch is linked with.
+    BoolParameter _param;
+    bool _state;
+    OwnedImage!RGBA _onImage;
+    OwnedImage!RGBA _offImage;
+
+private:
+    float _animation;
+}

--- a/flatwidgets/dplug/flatwidgets/package.d
+++ b/flatwidgets/dplug/flatwidgets/package.d
@@ -1,0 +1,14 @@
+/**
+* Copyright: Copyright Auburn Sounds 2015 and later.
+* Copyright: Copyright Cut Through Recordings 2017
+* License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+* Authors:   Guillaume Piolat, Ethan Reker
+*/
+module dplug.flatwidgets;
+
+public import dplug.gui.element;
+
+// widgets
+public import dplug.flatwidgets.flatknob;
+public import dplug.flatwidgets.flatslider;
+public import dplug.flatwidgets.flatswitch;


### PR DESCRIPTION
This subpackage currently only contains

- UIFilmstripKnob (draws a knob from an filmstrip created with programs like knobman)
- UIFilmstripSlider (draws a slider from an filmstrip image)
- UIFlatSwitch (draws a switch from two images representing it's on and off states)

This adds the basic functionality necessary for pre-rendered UIs.  Some future additions that would be nice would be something similar to PBRBackgroundGUI but would take an image to draw as the background.  And a way to implement image based radio buttons would be nice also.