### PR TITLE
Allow DMD to link libphobos2 statically

### DIFF
--- a/examples/clipit/dub.json
+++ b/examples/clipit/dub.json
@@ -16,6 +16,8 @@
         "/nodefaultlib:vcruntime.lib"
     ],
 
+    "dflags-linux-dmd": ["-defaultlib=libphobos2.a"],
+
     "dependencies":
     {
         "dplug:dsp": { "path": "../.." },

--- a/examples/distort/dub.json
+++ b/examples/distort/dub.json
@@ -16,6 +16,8 @@
         "/nodefaultlib:vcruntime.lib"
     ],
 
+    "dflags-linux-dmd": ["-defaultlib=libphobos2.a"],
+
     "dependencies":
     {
         "dplug:dsp": { "path": "../.." },

--- a/examples/ms-encode/dub.json
+++ b/examples/ms-encode/dub.json
@@ -15,6 +15,8 @@
         "/nodefaultlib:vcruntime.lib"
     ],
 
+    "dflags-linux-dmd": ["-defaultlib=libphobos2.a"],
+
     "dependencies":
     {
         "dplug:vst": { "path": "../.." }

--- a/examples/simple-mono-synth/dub.json
+++ b/examples/simple-mono-synth/dub.json
@@ -15,6 +15,8 @@
         "/nodefaultlib:vcruntime.lib"
     ],
 
+    "dflags-linux-dmd": ["-defaultlib=libphobos2.a"],
+
     "dependencies":
     {
         "dplug:vst": { "path": "../.." }


### PR DESCRIPTION
On Linux, when using DMD compiler, the compiled examples were dynamically linked to `libphobos2.so`. In effect, none of the compiled plugins worked on Linux (on the other hand all worked when compiled using LDC). This PR makes DMD compiled examples work as expected (and they are way smalled than compiled using LDC).