### PR TITLE
Embed VST client in X11 parent window

### DIFF
--- a/window/dplug/window/window.d
+++ b/window/dplug/window/window.d
@@ -272,7 +272,7 @@ IWindow createWindow(WindowUsage usage,
         if (backend == WindowBackend.x11)
         {
             import dplug.window.x11window;
-            return mallocNew!X11Window(null, listener, width, height);
+            return mallocNew!X11Window(parentInfo, listener, width, height);
         }
         else
             return null;
@@ -282,4 +282,3 @@ IWindow createWindow(WindowUsage usage,
         static assert(false, "Unsupported OS.");
     }
 }
-

--- a/window/dplug/window/x11window.d
+++ b/window/dplug/window/x11window.d
@@ -1,8 +1,9 @@
 ﻿/**
  * X11 window implementation.
- * 
+ *
  * Copyright: Copyright (C) 2017 Richard Andrew Cattermole
  *            Copyright (C) 2017 Ethan Reker
+ *            Copyright (C) 2017 Lukasz Pelszynski
  *
  * Bugs:
  *     - X11 does not support double clicks, it is sometimes emulated https://github.com/glfw/glfw/issues/462
@@ -115,6 +116,11 @@ nothrow:
 
         _closeAtom = assumeNoGC(&XInternAtom)(_display, cast(char*)("WM_DELETE_WINDOW".ptr), cast(Bool)false);
         assumeNoGC(&XSetWMProtocols)(_display, _windowId, &_closeAtom, 1);
+
+        if (parentWindow) {
+          // Embed the window in parent (most VST hosts expose some area for embedding a VST client)
+          assumeNoGC(&XReparentWindow)(_display, _windowId, _parentWindowId, 0, 0);
+        }
 
         assumeNoGC(&XMapWindow)(_display, _windowId);
         assumeNoGC(&XFlush)(_display);
@@ -522,4 +528,3 @@ MouseState mouseStateFromX11(uint state) {
         (state & ShiftMask) == ShiftMask,
         (state & Mod1Mask) == Mod1Mask);
 }
-


### PR DESCRIPTION
VST client is usually embedded in some parent window provided by host. This pull request makes plugins created with DPlug work with Linux hosts like Ardour, Renoise and Carla. 