### PR TITLE
Fix MidiMessage.channel()

### DIFF
--- a/client/dplug/client/midi.d
+++ b/client/dplug/client/midi.d
@@ -49,7 +49,7 @@ nothrow:
     /// Returns: [0 .. 15]
     int channel() const
     {
-        return status & 0x0F;
+        return _status & 0x0F;
     }
 
     /// Status Type


### PR DESCRIPTION
The `channel()` property function used the status code `status()` instead of the status byte `_status`.

One should probably also rename `status()` to `midiStatus()`.