### PR TITLE
 Add support for implicit 'Note Off' MIDI messages

### DIFF
--- a/client/dplug/client/midi.d
+++ b/client/dplug/client/midi.d
@@ -108,6 +108,8 @@ nothrow:
     ///
     /// Background:
     ///     Some devices send a 'Note On' message with a velocity value of zero instead of a real 'Note Off' message.
+    ///     Many DAWs will automatically convert such ones to explicit ones, but one cannot rely on this.
+    ///     If developed software is not a plugin, there actually is not even a DAW that could perform this conversion.
     ///
     /// See_Also:
     ///     isNoteOff(),

--- a/client/dplug/client/midi.d
+++ b/client/dplug/client/midi.d
@@ -109,7 +109,7 @@ nothrow:
     /// Background:
     ///     Some devices send a 'Note On' message with a velocity value of zero instead of a real 'Note Off' message.
     ///     Many DAWs will automatically convert such ones to explicit ones, but one cannot rely on this.
-    ///     If developed software is not a plugin, there actually is not even a DAW that could perform this conversion.
+    ///     If the developed software is not a plugin, there is not even a DAW that could perform this conversion actually.
     ///
     /// See_Also:
     ///     isNoteOff(),

--- a/client/dplug/client/midi.d
+++ b/client/dplug/client/midi.d
@@ -22,7 +22,7 @@ module dplug.client.midi;
 import std.algorithm.mutation;
 import dplug.core.vec;
 
-/// It's the same abstraction that in IPlug.
+/// This abstraction is similar to the one in IPlug.
 /// For VST raw MIDI messages are passed.
 /// For AU MIDI messages gets synthesized.
 struct MidiMessage
@@ -73,14 +73,58 @@ nothrow:
         return statusType() == MidiStatus.controlChange;
     }
 
+    /// Checks whether the status type of the message is 'Note On'.
+    /// Doesn't consider the velocity value.
+    ///
+    /// See_Also: isNoteOnActual()
     bool isNoteOn() const
     {
         return statusType() == MidiStatus.noteOn;
     }
 
+    /// Checks whether the status type of the message is 'Note On'
+    /// and the velocity value is actually greater than zero.
+    ///
+    /// See_Also:
+    ///     isNoteOn(),
+    ///     isNoteOffImplicit()
+    bool isNoteOnActual() const
+    {
+        return isNoteOn() && (noteVelocity() > 0);
+    }
+
+    /// Checks whether the status type of the message is 'Note Off'.
+    /// Doesn't consider the velocity value.
+    ///
+    /// See_Also: isNoteOffImplicit()
     bool isNoteOff() const
     {
         return statusType() == MidiStatus.noteOff;
+    }
+
+    /// Checks whether the message is an implicit 'Note Off' message.
+    /// This means the message would be a 'Note On' message according to its status type
+    /// but its velocity value equals zero.
+    ///
+    /// Background:
+    ///     Some devices send a 'Note On' message with a velocity value of zero instead of a real 'Note Off' message.
+    ///
+    /// See_Also:
+    ///     isNoteOff(),
+    ///     isNoteOffAny()
+    bool isNoteOffImplicit() const
+    {
+        return isNoteOn() && (noteVelocity() == 0);
+    }
+
+    /// Checks whether the message is 'Note Off' message regardless of whether explicit or implicit.
+    ///
+    /// See_Also:
+    ///     isNoteOff(),
+    ///     isNoteOffImplicit()
+    bool isNoteOffAny() const
+    {
+        return isNoteOff() || isNoteOffImplicit();
     }
 
     bool isPitchBend() const

--- a/examples/simple-mono-synth/simplemonosynth.d
+++ b/examples/simple-mono-synth/simplemonosynth.d
@@ -53,9 +53,23 @@ nothrow:
     {
         foreach(msg; getNextMidiMessages(frames))
         {
-            if (msg.isNoteOn())
+            // A wee bit faster version:
+            //
+            // if (msg.isNoteOn())
+            // {
+            //     if (msg.noteVelocity() > 0)
+            //         _voiceStatus.markNoteOn(msg.noteNumber());
+            //     else // implicit note off
+            //         _voiceStatus.markNoteOff(msg.noteNumber());
+            // }
+            // else if (msg.isNoteOff)
+            // {
+            //     _voiceStatus.markNoteOff(msg.noteNumber());
+            // }
+
+            if (msg.isNoteOnActual())
                 _voiceStatus.markNoteOn(msg.noteNumber());
-            if (msg.isNoteOff())
+            else if (msg.isNoteOffAny())
                 _voiceStatus.markNoteOff(msg.noteNumber());
         }
 


### PR DESCRIPTION
## Technical background
> Some devices send a 'Note On' message with a velocity value of zero instead of a real 'Note Off' message.
> Many DAWs will automatically convert such ones to explicit ones, but one cannot rely on this.
> If developed software is not a plugin, there actually is not even a DAW that could perform this conversion.

## Background
 - 🎹 M-Audio Keystation Mini 32 MKII
 - 🎼 SoundBridge v1.07
 - 🔌 simple-mono-synth
- 😧😵🤔 me

## Notes
This also introduces new methods in `MidiMessage`. If you don't like their namings or documentation texts, or if there are any other concerns, please let me know 😄