### PR TITLE
Add "Poly Alias" - a new polyphonic example synth

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Keep up with major changes here: [Release Notes](https://github.com/AuburnSounds
 
 - Does Dplug support the creation of synthesizer plug-ins?
 
-Yes. See simple-mono-synth example.
+Yes. See [simple-mono-synth](examples/simple-mono-synth) and [Poly Alias](examples/poly-alias-synth) examples.
 
 - Am I forced to use the PBR rendering system?
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,6 +2,7 @@
    * `examples/distort`: mandatory distortion plugin, with a PBR UI
    * `examples/clipit`: mandatory distortion plugin, with a flat UI
    * `examples/ms-encode`: simplest plugin for tutorial purpose, without UI
+   * `examples/poly-alias-synth`: simple polyphonic wave generator, without UI
    * `examples/simple-mono-synth`: very basic sine-wave generator, without UI
    * `examples/window`: for windowing testing
 

--- a/examples/poly-alias-synth/README.md
+++ b/examples/poly-alias-synth/README.md
@@ -1,0 +1,21 @@
+# <img src="poly-alias-logo.svg" alt="Poly Alias - Open Source Example Synth"/>
+
+**Poly Alias** is a modern synth taking full advantage of the possibilities of digital audio signals.
+
+It's *fine-tuned* algorithms allow to get the **harshest sounds** possible - no smoothing, no filtering, but with **maximum aliasing**.
+Your DAC will gonna love you. And you're listeners will, too. *(...might depend on their tastes, though)*
+
+
+## Features
+
+- **Polyphonic** - up to 4 voices<br/>*...or even more! (if you change `maxVoices` in [polyalias.d](polyalias.d#L14))*
+- **3 different waveforms**<br/>*saw, sine, square* - all modelled after the textbooks  as closely as possible
+- **Simple + focused**<br/>*no (unnecessary) filters or LFOs*
+- **Purity**<br/>*as pure sound as possible - no built-in FX*
+- **Native UI** (matching your host)<br/>*instead of a beatiful GUI crafted with love it will just let your plugin host create the UI*
+
+
+## Extras
+
+This all is a joke (and maybe also a parody) and should not be taken too serious. But I guess you've already got it... 😊
+<br/>Nevertheless, this software is a fine example poly-synth.

--- a/examples/poly-alias-synth/README.md
+++ b/examples/poly-alias-synth/README.md
@@ -11,7 +11,7 @@ Your DAC will gonna love you. And you're listeners will, too. *(...might depend 
 - **Polyphonic** - up to 4 voices<br/>*...or even more! (if you change `maxVoices` in [polyalias.d](polyalias.d#L14))*
 - **3 different waveforms**<br/>*saw, sine, square* - all modelled after the textbooks  as closely as possible
 - **Simple + focused**<br/>*no (unnecessary) filters or LFOs*
-- **Purity**<br/>*as pure sound as possible - no built-in FX*
+- **Purity**<br/>*sounds as pure as possible - no built-in FX*
 - **Native UI** (matching your host)<br/>*instead of a beatiful GUI crafted with love it will just let your plugin host create the UI*
 
 

--- a/examples/poly-alias-synth/dub.json
+++ b/examples/poly-alias-synth/dub.json
@@ -1,0 +1,40 @@
+{
+    "$schema": "https://raw.githubusercontent.com/Pure-D/code-d/master/json-validation/dub.schema.json",
+
+    "name": "poly-alias-synth",
+
+    "importPaths": [ "." ],
+    "sourcePaths": [ "." ],
+    "stringImportPaths": [ "." ],
+
+    "targetType": "dynamicLibrary",
+
+    "lflags-windows-ldc": [
+        "libcmt.lib",
+        "/nodefaultlib:msvcrt.lib",
+        "/nodefaultlib:vcruntime.lib"
+    ],
+
+    "dflags-linux-dmd": ["-defaultlib=libphobos2.a"],
+
+    "dflags-osx-ldc": ["-static"],
+
+    "comment-WARNING-READ-THIS-IS-IMPORTANT": [
+        "    When making your own plug-in you have to CHANGE THESE DEPENDENCY    ",
+        "    SPECIFICATIONS below from path-based to ~>MAJOR.MINOR               ",
+        "      Example: ~>7.0                                                    ",
+        "    See also the DUB documentation:                                     ",
+        "         https://code.dlang.org/package-format?lang=json#version-specs  "],
+    "dependencies":
+    {
+        "dplug:vst": { "path": "../.." }
+    },
+
+    "configurations": [
+        {
+            "name": "VST",
+            "versions": ["VST"],
+            "targetType": "dynamicLibrary"
+        }
+    ]
+}

--- a/examples/poly-alias-synth/plugin.json
+++ b/examples/poly-alias-synth/plugin.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://raw.githubusercontent.com/AuburnSounds/dplug/master/plugin-schema.json",
+
+    "vendorName": "No Name Audio",
+    "vendorUniqueID": "NoAu",
+    "pluginName": "Poly Alias",
+    "pluginUniqueID": "NAps",
+    "publicVersion": "1.0.0",
+    "CFBundleIdentifierPrefix": "com.nonameaudio",
+    "hasGUI": false,
+    "isSynth": true,
+    "receivesMIDI": true,
+    "category": "instrumentSynthesizer"
+}

--- a/examples/poly-alias-synth/poly-alias-logo.svg
+++ b/examples/poly-alias-synth/poly-alias-logo.svg
@@ -1,0 +1,16 @@
+<svg width="700" height="70" xmlns="http://www.w3.org/2000/svg">
+    <g>
+        <title>Poly Alias - Open Source Example Synth</title>
+        <g display="none" overflow="visible" y="0" x="0" height="100%" width="100%" id="canvasGrid">
+            <rect fill="url(#gridpattern)" stroke-width="0" y="0" x="0" height="100%" width="100%"/>
+        </g>
+    </g>
+    <g>
+        <line x1="0" y1="0" x2="700" y2="0" stroke-width="4" stroke="#000000"/>
+        <line x1="0" y1="70" x2="700" y2="70" stroke-width="4" stroke="#000000"/>
+        <line x1="0" y1="0" x2="0" y2="70" stroke-width="4" stroke="#000000"/>
+        <line x1="700" y1="0" x2="700" y2="70" stroke-width="4" stroke="#000000"/>
+        <text style="cursor: move;" xml:space="preserve" text-anchor="start" font-family="monospace" font-size="36" x="16" y="47" stroke-width="0" stroke="#C34" fill="#C34">🎹 Poly Alias</text>
+        <text xml:space="preserve" text-anchor="start" font-family="monospace" font-size="22" x="326" y="47" stroke-width="0" stroke="#C97A86" fill="#000000">Open Source Example Synth</text>
+    </g>
+</svg>

--- a/examples/poly-alias-synth/poly-alias-logo.svg
+++ b/examples/poly-alias-synth/poly-alias-logo.svg
@@ -1,10 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.0//EN" "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
 <svg width="700" height="70" xmlns="http://www.w3.org/2000/svg">
-    <g>
-        <title>Poly Alias - Open Source Example Synth</title>
-        <g display="none" overflow="visible" y="0" x="0" height="100%" width="100%" id="canvasGrid">
-            <rect fill="url(#gridpattern)" stroke-width="0" y="0" x="0" height="100%" width="100%"/>
-        </g>
-    </g>
     <g>
         <line x1="0" y1="0" x2="700" y2="0" stroke-width="4" stroke="#000000"/>
         <line x1="0" y1="70" x2="700" y2="70" stroke-width="4" stroke="#000000"/>

--- a/examples/poly-alias-synth/polyalias.d
+++ b/examples/poly-alias-synth/polyalias.d
@@ -1,0 +1,107 @@
+import std.math;
+import dplug.core, dplug.client, dplug.vst;
+import synthesis;
+
+// This create the DLL entry point
+mixin(DLLEntryPoint!());
+
+// This create the VST entry point
+mixin(VSTEntryPoint!PolyAlias);
+
+private
+{
+    // Number of max notes playing at the same time
+    enum maxVoices = 4;
+
+    enum Params : int
+    {
+        osc1WaveForm,
+    }
+
+    immutable waveFormNames = [__traits(allMembers, WaveForm)];
+}
+
+/// Polyphonic digital-aliasing synth
+final class PolyAlias : dplug.client.Client
+{
+nothrow @nogc:
+
+    private
+    {
+        Synth!maxVoices _synth;
+    }
+
+    public this()
+    {
+        super();
+
+        assumeNothrowNoGC((PolyAlias this_) {
+            this_._synth = mallocNew!(typeof(this._synth))(WaveForm.saw);
+        })(this);
+    }
+
+    public override
+    {
+        PluginInfo buildPluginInfo()
+        {
+            // Plugin info is parsed from plugin.json here at compile time.
+            // Indeed it is strongly recommended that you do not fill PluginInfo
+            // manually, else the information could diverge.
+            static immutable PluginInfo pluginInfo = parsePluginInfo(import("plugin.json"));
+            return pluginInfo;
+        }
+
+        override Parameter[] buildParameters()
+        {
+            auto params = makeVec!Parameter();
+            params.pushBack(mallocNew!EnumParameter(Params.osc1WaveForm, "Osc 1: Waveform", waveFormNames, 0));
+            return params.releaseData();
+        }
+
+        override LegalIO[] buildLegalIO()
+        {
+            auto io = makeVec!LegalIO();
+            io.pushBack(LegalIO(0, 1));
+            io.pushBack(LegalIO(0, 2));
+            return io.releaseData();
+        }
+
+        override int maxFramesInProcess() pure const
+        {
+            return 32; // samples only processed by a maximum of 32 samples
+        }
+
+        override void reset(double sampleRate, int maxFrames, int numInputs, int numOutputs)
+        {
+            this._synth.reset(sampleRate);
+        }
+
+        override void processAudio(const(float*)[] inputs, float*[] outputs, int frames, TimeInfo info)
+        {
+            foreach (msg; getNextMidiMessages(frames))
+            {
+                if (msg.isNoteOn())
+                {
+                    this._synth.markNoteOn(msg.noteNumber());
+                }
+                else if (msg.isNoteOff())
+                {
+                    this._synth.markNoteOff(msg.noteNumber());
+                }
+            }
+
+            this._synth.waveForm = cast(WaveForm)(readEnumParamValue(Params.osc1WaveForm));
+
+            foreach (ref sample; outputs[0][0 .. frames])
+            {
+                sample = this._synth.synthesizeNext();
+            }
+
+            // Copy output to every channel
+            foreach (chan; 1 .. outputs.length)
+            {
+                outputs[chan][0 .. frames] = outputs[0][0 .. frames];
+            }
+        }
+    }
+}

--- a/examples/poly-alias-synth/polyalias.d
+++ b/examples/poly-alias-synth/polyalias.d
@@ -2,10 +2,10 @@ import std.math;
 import dplug.core, dplug.client, dplug.vst;
 import synthesis;
 
-// This create the DLL entry point
+// This creates the DLL entry point
 mixin(DLLEntryPoint!());
 
-// This create the VST entry point
+// This creates the VST entry point
 mixin(VSTEntryPoint!PolyAlias);
 
 private

--- a/examples/poly-alias-synth/synthesis.d
+++ b/examples/poly-alias-synth/synthesis.d
@@ -1,0 +1,308 @@
+module synthesis;
+
+import std.math;
+import dplug.core.nogc;
+import dplug.core.math;
+
+enum TAU = 2 * PI;
+
+enum WaveForm
+{
+    saw,
+    sine,
+    square,
+}
+
+final class Oscillator
+{
+@safe pure nothrow @nogc:
+
+    private
+    {
+        float _frequency;
+        float _phase = 0;
+        float _phaseSummand;
+        float _sampleRate;
+        WaveForm _waveForm;
+    }
+
+    public
+    {
+        @property
+        {
+            void frequency(float value)
+            {
+                this._frequency = value;
+                this.updatePhaseSummand();
+            }
+        }
+
+        @property
+        {
+            void sampleRate(float value)
+            {
+                this._sampleRate = value;
+                this.updatePhaseSummand();
+            }
+        }
+
+        @property
+        {
+            WaveForm waveForm()
+            {
+                return this._waveForm;
+            }
+
+            void waveForm(WaveForm value)
+            {
+                this._waveForm = value;
+            }
+        }
+    }
+
+    public this(WaveForm waveForm)
+    {
+        this._waveForm = waveForm;
+        this.updatePhaseSummand();
+    }
+
+    public
+    {
+        float synthesizeNext()
+        {
+            float sample = void;
+
+            final switch (this._waveForm) with (WaveForm)
+            {
+            case saw:
+                sample = 1.0 - (this._phase / PI);
+                break;
+
+            case sine:
+                sample = sin(this._phase);
+                break;
+
+            case square:
+                sample = (this._phase <= PI) ? 1.0 : -1.0;
+                break;
+            }
+
+            this._phase += this._phaseSummand;
+            while (this._phase >= TAU)
+            {
+                this._phase -= TAU;
+            }
+
+            return sample;
+        }
+    }
+
+    private
+    {
+        void updatePhaseSummand()
+        {
+            pragma(inline, true);
+            this._phaseSummand = (this._frequency * TAU / this._sampleRate);
+            //this._phase = 0;
+        }
+    }
+}
+
+final class VoiceStatus
+{
+@safe nothrow @nogc:
+
+    private
+    {
+        Oscillator _osc;
+        bool _isPlaying;
+        int _note;
+    }
+
+    public pure
+    {
+        @property
+        {
+            bool isPlaying()
+            {
+                return this._isPlaying;
+            }
+        }
+
+        @property
+        {
+            int note()
+            {
+                return this._note;
+            }
+        }
+
+        @property
+        {
+            void waveForm(WaveForm value)
+            {
+                this._osc.waveForm = value;
+            }
+
+            WaveForm waveForm()
+            {
+                return this._osc.waveForm;
+            }
+        }
+    }
+
+    public this(WaveForm waveForm) @system
+    {
+        this._osc = mallocNew!Oscillator(waveForm);
+        this._note = -1;
+    }
+
+    public pure
+    {
+        void play(int note) @trusted
+        {
+            this._note = note;
+            this._osc.frequency = convertMIDINoteToFrequency(note);
+            this._isPlaying = true;
+        }
+
+        void release()
+        {
+            this._isPlaying = false;
+        }
+
+        void reset(float sampleRate)
+        {
+            this.release();
+            this._osc.sampleRate = sampleRate;
+        }
+
+        float synthesizeNext()
+        {
+            if (!this._isPlaying)
+            {
+                return 0;
+            }
+
+            return this._osc.synthesizeNext();
+        }
+    }
+}
+
+final class Synth(size_t voicesCount)
+{
+    static assert(voicesCount > 0, "A synth must have at least 1 voice.");
+
+@safe nothrow:
+
+    private
+    {
+        VoiceStatus[voicesCount] _voices;
+    }
+
+    public pure @nogc
+    {
+        @property bool isPlaying()
+        {
+            foreach(v; this._voices)
+            {
+                if (v.isPlaying())
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @property
+        {
+            WaveForm waveForm()
+            {
+                return this._voices[0].waveForm;
+            }
+
+            void waveForm(WaveForm value)
+            {
+                foreach (v; this._voices)
+                {
+                    v.waveForm = value;
+                }
+            }
+        }
+    }
+
+    public this(WaveForm waveForm) @system
+    {
+        foreach (ref v; this._voices)
+        {
+            v = mallocNew!VoiceStatus(waveForm);
+        }
+    }
+
+    public pure @nogc
+    {
+        void markNoteOn(int note)
+        {
+            VoiceStatus v = this.getUnusedVoice();
+            if (v is null)
+            {
+                /+
+                    No voice available
+
+                    well, one could override one, but:
+                     - always overriding the 1st one is lame
+                     - a smart algorithm would make this example more complicated
+                +/
+                return;
+            }
+
+            v.play(note);
+        }
+
+        void markNoteOff(int note)
+        {
+            foreach (v; this._voices)
+            {
+                if (v.isPlaying && (v.note == note))
+                {
+                    v.release();
+                }
+            }
+        }
+
+        void reset(float sampleRate)
+        {
+            foreach (v; this._voices)
+            {
+                v.reset(sampleRate);
+            }
+        }
+
+        float synthesizeNext()
+        {
+            float sample = 0;
+
+            foreach (v; this._voices)
+            {
+                sample += (v.synthesizeNext() / voicesCount); // synth + lower volume
+            }
+
+            return sample;
+        }
+    }
+
+    private
+    {
+        VoiceStatus getUnusedVoice()
+        {
+            foreach (v; this._voices)
+            {
+                if (!v.isPlaying)
+                {
+                    return v;
+                }
+            }
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
I've created a new example synth :blush:
(well, in fact I've extracted the code from previous personal creations and refactored it).

It's name explains its functionality pretty well: it's polyphonic and its sound aliases like hot cakes. Furthermore, it features 3 raw digital waveforms (saw, square, sine) that can be changed via its only automation parameter. So it doesn't have a GUI.

If one doesn't demand overly high standards of it, it could be a solid base one can build a real synth plugin on. Basically it contains all the required "boilerplate" and "framework", but still misses the fun parts of synthesizer programming.

Please don't take the bundled [readme](https://github.com/0xEAB/dplug/blob/d03d6898adff38e94ab418f497b0973569f2d601/examples/poly-alias-synth/README.md) too serious (as written at the end of its text, it's a parody on grossly overstated product descriptions). If you think it oversteps the mark, I won't mind having it removed.