### PR TITLE
fix lv2 windows issue with multiple __gshared declarations of uriMap

### DIFF
--- a/lv2/dplug/lv2/client.d
+++ b/lv2/dplug/lv2/client.d
@@ -57,24 +57,20 @@ import dplug.lv2.lv2,
        dplug.lv2.urid,
        dplug.lv2.bufsize;
 
-// __gshared Map!(string, int) uriMap;
-extern(C)
-{
-    __gshared Map!(string, int) uriMap;
-}
-
-
 class LV2Client : IHostCommand
 {
 nothrow:
 @nogc:
 
     Client _client;
-    this(Client client)
+    Map!(string, int)* _uriMap;
+
+    this(Client client, Map!(string, int)* uriMapPtr)
     {
         _client = client;
         _client.setHostCommand(this);
         _graphicsMutex = makeMutex();
+        _uriMap = uriMapPtr;
     }
 
     void instantiate(const LV2_Descriptor* descriptor, double rate, const char* bundle_path, const(LV2_Feature*)* features)
@@ -101,7 +97,7 @@ nothrow:
 
         // Retrieve index of legalIO that was stored in the uriMap
         string uri = cast(string)descriptor.URI[0..strlen(descriptor.URI)];
-        int legalIOIndex = uriMap[uri];
+        int legalIOIndex = (*_uriMap)[uri];
 
         LegalIO selectedIO = _client.legalIOs()[legalIOIndex];
 

--- a/lv2/dplug/lv2/lv2_init.d
+++ b/lv2/dplug/lv2/lv2_init.d
@@ -91,7 +91,7 @@ extern(C)
 nothrow LV2Client myLV2EntryPoint(alias ClientClass)(const LV2_Descriptor* descriptor, double rate, const char* bundle_path, const(LV2_Feature*)* features)
 {
     auto client = mallocNew!ClientClass();
-    auto lv2client = mallocNew!LV2Client(client);
+    auto lv2client = mallocNew!LV2Client(client, &uriMap);
     lv2client.instantiate(descriptor, rate, bundle_path, features);
     return lv2client;
 }


### PR DESCRIPTION
Turns out that declaring `uriMap` in both files isn't necessary.  It can be passed to the client in its constructor.