### PR TITLE
 Fix #337 - X11Window no longer swaps buffers manually. Also fixes #345

### DIFF
--- a/lv2/dplug/lv2/lv2client.d
+++ b/lv2/dplug/lv2/lv2client.d
@@ -359,7 +359,7 @@ nothrow:
     {
         debug(debugLV2Client) debugLog(">instantiateUI");
 
-        void* transientWin = null;
+        int transientWinId;
         void* parentId = null;
         LV2_Options_Option* options = null;
         LV2UI_Resize* uiResize = null;

--- a/window/dplug/window/x11window.d
+++ b/window/dplug/window/x11window.d
@@ -70,17 +70,24 @@ private:
     Atom _closeAtom;
     derelict.x11.Xlib.GC _graphicGC;
     XImage* _graphicImage;
-    int width, height, depth;
+    int depth;
     // Threads
     Thread _eventLoop, _timerLoop;
-    UncheckedMutex drawMutex;
+    // UncheckedMutex drawMutex;
     //Other
-    IWindowListener listener;
+    IWindowListener _listener;
 
     ImageRef!RGBA _wfb; // framebuffer reference
     ubyte[4][] _bufferData;
+    
+    uint _timeAtCreationInMs;
+    uint _lastMeasturedTimeInMs;
+    bool _dirtyAreasAreNotYetComputed;
 
-    uint lastTimeGot, creationTime, currentTime;
+    int _width;
+    int _height;
+
+    uint currentTime;
     int lastMouseX, lastMouseY;
 
     box2i prevMergedDirtyRect, mergedDirtyRect;
@@ -95,12 +102,11 @@ private:
 public:
     this(void* parentWindow, /* void* transientWindowId,*/ IWindowListener listener, int width, int height)
     {
-        debug(logX11Window) fprintf(stderr, "X11Window: constructor\n");
-        drawMutex = makeMutex();
+        debug(logX11Window) printf("X11Window: constructor\n");
         initializeXLib();
 
         int x, y;
-        this.listener = listener;
+        _listener = listener;
 
         if (parentWindow is null)
         {
@@ -113,19 +119,20 @@ public:
 
         x = (DisplayWidth(_display, _screen) - width) / 2;
         y = (DisplayHeight(_display, _screen) - height) / 3;
-        this.width = width;
-        this.height = height;
+        _width = width;
+        _height = height;
+        _wfb = _listener.onResized(_width, _height);
         depth = 24;
 
-        _windowId = XCreateSimpleWindow(_display, _parentWindowId, x, y, width, height, 0, 0, _black_pixel);
+        _windowId = XCreateSimpleWindow(_display, _parentWindowId, x, y, _width, _height, 0, 0, _black_pixel);
         //XStoreName(_display, _windowId, cast(char*)transientWindowId);
 
         XSizeHints sizeHints;
         sizeHints.flags = PMinSize | PMaxSize;
-        sizeHints.min_width = width;
-        sizeHints.max_width = width;
-        sizeHints.min_height = height;
-        sizeHints.max_height = height;
+        sizeHints.min_width = _width;
+        sizeHints.max_width = _width;
+        sizeHints.min_height = _height;
+        sizeHints.max_height = _height;
 
         XSetWMNormalHints(_display, _windowId, &sizeHints);
 
@@ -145,11 +152,6 @@ public:
             XReparentWindow(_display, _windowId, _parentWindowId, 0, 0);
         }
 
-        /*if(transientWindowId)
-        {
-            XSetTransientForHint(_display, _windowId, cast(Window)transientWindowId);
-        }*/
-
         XMapWindow(_display, _windowId);
         XFlush(_display);
 
@@ -158,10 +160,9 @@ public:
         XSetBackground(_display, _graphicGC, _white_pixel);
         XSetForeground(_display, _graphicGC, _black_pixel);
 
-        _wfb = listener.onResized(width, height);
+        _lastMeasturedTimeInMs = _timeAtCreationInMs = getTimeMs();
 
-        creationTime = getTimeMs();
-        lastTimeGot = creationTime;
+        _dirtyAreasAreNotYetComputed = true;
 
         emptyMergedBoxes();
 
@@ -174,15 +175,15 @@ public:
     }
 
     ~this()
-    {
+    { 
         XDestroyWindow(_display, _windowId);
         XFlush(_display);
+        _terminated = true;
         _timerLoop.join();
         _eventLoop.join();
     }
 
     void initializeXLib() {
-        drawMutex.lock();
         if (!XLibInitialized) {
             XInitThreads();
 
@@ -198,7 +199,6 @@ public:
 
             XLibInitialized = true;
         }
-        drawMutex.unlock();
     }
 
     long windowEventMask() {
@@ -206,151 +206,99 @@ public:
             KeyReleaseMask | KeyPressMask | ButtonReleaseMask | ButtonPressMask | PointerMotionMask;
     }
 
-    void swapBuffers(ImageRef!RGBA wfb, box2i[] areasToRedraw)
-    {
-        if (_bufferData.length != wfb.w * wfb.h)
-        {
-            _bufferData = mallocSlice!(ubyte[4])(wfb.w * wfb.h);
-
-            if (_graphicImage !is null)
-            {
-                // X11 deallocates _bufferData for us (ugh...)
-                XDestroyImage(_graphicImage);
-            }
-
-            _graphicImage = XCreateImage(_display, _visual, depth, ZPixmap, 0, cast(char*)_bufferData.ptr, width, height, 32, 0);
-
-            // PERF: there is no reason to do reordering here, since pixels can be requested to be BGRA8 in the onDraw call
-            size_t i;
-            foreach(y; 0 .. wfb.h)
-            {
-                RGBA[] scanLine = wfb.scanline(y);
-                foreach(x, ref c; scanLine)
-                {
-                    _bufferData[i][0] = c.b;
-                    _bufferData[i][1] = c.g;
-                    _bufferData[i][2] = c.r;
-                    _bufferData[i][3] = c.a;
-                    i++;
-                }
-            }
-        }
-        else
-        {
-            // PERF: there is no reason to do reordering here, since pixels can be requested to be BGRA8 in the onDraw call
-            foreach(box2i area; areasToRedraw)
-            {
-                foreach(y; area.min.y .. area.max.y)
-                {
-                    RGBA[] scanLine = wfb.scanline(y);
-
-                    size_t i = y * wfb.w;
-                    i += area.min.x;
-
-                    foreach(x, ref c; scanLine[area.min.x .. area.max.x])
-                    {
-                        _bufferData[i][0] = c.b;
-                        _bufferData[i][1] = c.g;
-                        _bufferData[i][2] = c.r;
-                        _bufferData[i][3] = c.a;
-                        i++;
-                    }
-                }
-            }
-        }
-
-        XPutImage(_display, _windowId, _graphicGC, _graphicImage, 0, 0, 0, 0, cast(uint)width, cast(uint)height);
-    }
-
     // Implements IWindow
     override void waitEventAndDispatch() nothrow @nogc
     {
-        // fprintf(stderr, "X11Window: waitEventAndDispatch()\n");
+        debug(logX11Window) printf("< waitEventAndDispatch\n");
         XEvent event;
         // Wait for events for current window
         XWindowEvent(_display, _windowId, windowEventMask(), &event);
         handleEvents(event, this);
+        debug(logX11Window) printf("> waitEventAndDispatch\n");
     }
 
     void eventLoop() nothrow @nogc
     {
-        // fprintf(stderr, "X11Window: eventLoop()\n");
+        debug(logX11Window) printf("< eventLoop\n");
         while (!terminated()) {
             waitEventAndDispatch();
         }
+        debug(logX11Window) printf("> eventLoop\n");
     }
 
     void emptyMergedBoxes() nothrow @nogc
     {
+        debug(logX11Window) printf("< emptyMergedBoxes\n");
         prevMergedDirtyRect = box2i(0,0,0,0);
         mergedDirtyRect = box2i(0,0,0,0);
+        debug(logX11Window) printf("> emptyMergedBoxes\n");
     }
 
     void sendRepaintIfUIDirty() nothrow @nogc
     {
-        listener.recomputeDirtyAreas();
-        box2i dirtyRect = listener.getDirtyRectangle();
+        debug(logX11Window) printf("< sendRepaintIfUIDirty\n");
+        _listener.recomputeDirtyAreas();
+        box2i dirtyRect = _listener.getDirtyRectangle();
         if (!dirtyRect.empty())
         {
-            prevMergedDirtyRect = mergedDirtyRect;
-            mergedDirtyRect = mergedDirtyRect.expand(dirtyRect);
-            // If everything has been drawn by Expose event handler, send Expose event.
-            // Otherwise merge areas to be redrawn and postpone Expose event.
-            if (prevMergedDirtyRect.empty() && !mergedDirtyRect.empty()) {
-                int x = dirtyRect.min.x;
-                int y = dirtyRect.min.y;
-                int width = dirtyRect.max.x - x;
-                int height = dirtyRect.max.y - y;
+            XEvent evt;
+            memset(&evt, 0, XEvent.sizeof);
+            evt.type = Expose;
+            evt.xexpose.window = _windowId;
+            evt.xexpose.display = _display;
+            evt.xexpose.x = dirtyRect.min.x;
+            evt.xexpose.y = dirtyRect.min.y;
+            evt.xexpose.width = dirtyRect.width;
+            evt.xexpose.height = dirtyRect.height;
 
-                XEvent evt;
-                memset(&evt, 0, XEvent.sizeof);
-                evt.type = Expose;
-                evt.xexpose.window = _windowId;
-                evt.xexpose.display = _display;
-                evt.xexpose.x = 0;
-                evt.xexpose.y = 0;
-                evt.xexpose.width = 0;
-                evt.xexpose.height = 0;
-
-                XSendEvent(_display, _windowId, False, ExposureMask, &evt);
-                XFlush(_display);
-            }
+            XSendEvent(_display, _windowId, False, ExposureMask, &evt);
+            XFlush(_display);
         }
+        debug(logX11Window) printf("> sendRepaintIfUIDirty\n");
+    }
+
+    void doAnimation()
+    {
+        uint now = getTimeMs();
+        double dt = (now - _lastMeasturedTimeInMs) * 0.001;
+        double time = (now - _timeAtCreationInMs) * 0.001; // hopefully no plug-in will be open more than 49 days
+        _lastMeasturedTimeInMs = now;
+        _listener.onAnimate(dt, time);
     }
 
     void timerLoop() nothrow @nogc
     {
-        debug(logX11Window) fprintf(stderr, "X11Window: timerLoop()\n");
+        debug(logX11Window) printf("< timerLoop\n");
         while(!terminated())
         {
-            currentTime = getTimeMs();
-            float diff = currentTime - lastTimeGot;
-            double dt = (currentTime - lastTimeGot) * 0.001;
-            double time = (currentTime - creationTime) * 0.001;
-            listener.onAnimate(dt, time);
+            doAnimation();
+
+            _listener.recomputeDirtyAreas();
+            _dirtyAreasAreNotYetComputed = false;
+
             sendRepaintIfUIDirty();
-            lastTimeGot = currentTime;
-            //Sleep for ~16.6 milliseconds (60 frames per second rendering)
-            usleep(16666);
+            sleep(1 / 60);
         }
+        debug(logX11Window) printf("> timerLoop\n");
     }
 
     override bool terminated()
     {
-        debug(logX11Window) fprintf(stderr, "X11Window: terminated()\n");
         return atomicLoad(_terminated);
     }
 
     override uint getTimeMs()
     {
+        debug(logX11Window) printf("< getTimeMs\n");
         static uint perform() {
+            debug(logX11Window) printf("< perform\n");
             import core.sys.posix.sys.time;
             timeval  tv;
             gettimeofday(&tv, null);
-            return cast(uint)((tv.tv_sec) * 1000 + (tv.tv_usec) / 1000) ;
-
+            debug(logX11Window) printf("> perform\n");
+            return cast(uint)((tv.tv_sec) * 1000 + (tv.tv_usec) / 1000 ) ;
         }
-
+        debug(logX11Window) printf("> getTimeMs\n");
         return assumeNothrowNoGC(&perform)();
     }
 
@@ -362,8 +310,7 @@ public:
 
 void handleEvents(ref XEvent event, X11Window theWindow) nothrow @nogc
 {
-    debug(logX11Window) fprintf(stderr, "X11Window: handleEvents()\n");
-    theWindow.drawMutex.lock();
+    debug(logX11Window) printf("< handleEvents\n");
     with(theWindow)
     {
         
@@ -372,43 +319,39 @@ void handleEvents(ref XEvent event, X11Window theWindow) nothrow @nogc
             case KeyPress:
                 KeySym symbol;
                 XLookupString(&event.xkey, null, 0, &symbol, null);
-                listener.onKeyDown(convertKeyFromX11(symbol));
+                _listener.onKeyDown(convertKeyFromX11(symbol));
                 break;
 
             case KeyRelease:
                 KeySym symbol;
                 XLookupString(&event.xkey, null, 0, &symbol, null);
-                listener.onKeyUp(convertKeyFromX11(symbol));
+                _listener.onKeyUp(convertKeyFromX11(symbol));
                 break;
 
             case MapNotify:
             case Expose:
-                // Resize should trigger Expose event, so we don't need to handle it here
-                
-
-                box2i areaToRedraw = mergedDirtyRect;
-                box2i eventAreaToRedraw = box2i(event.xexpose.x, event.xexpose.y, event.xexpose.x + event.xexpose.width, event.xexpose.y + event.xexpose.height);
-                areaToRedraw = areaToRedraw.expand(eventAreaToRedraw);
-
-                emptyMergedBoxes();
-
-                
-
-                if (!areaToRedraw.empty()) {
-                    listener.onDraw(WindowPixelFormat.RGBA8);
-                    box2i[] areasToRedraw = (&areaToRedraw)[0..1];
-                    swapBuffers(_wfb, areasToRedraw);
+                if (_dirtyAreasAreNotYetComputed)
+                {
+                    _dirtyAreasAreNotYetComputed = false;
+                    _listener.recomputeDirtyAreas();
                 }
+                
+                if(_graphicImage is null)
+                    _graphicImage = XCreateImage(_display, _visual, depth, ZPixmap, 0, cast(char*)_wfb.pixels, _width, _height, 32, 0);
+                XLockDisplay(_display);
+                _listener.onDraw(WindowPixelFormat.BGRA8);
+                XPutImage(_display, _windowId, _graphicGC, _graphicImage, 0, 0, 0, 0, cast(uint)_width, cast(uint)_height);
+                XUnlockDisplay(_display);
                 break;
 
             case ConfigureNotify:
-                if (event.xconfigure.width != width || event.xconfigure.height != height)
+                if (event.xconfigure.width != _width || event.xconfigure.height != _height)
                 {
                     // Handle resize event
-                    width = event.xconfigure.width;
-                    height = event.xconfigure.height;
+                    _width = event.xconfigure.width;
+                    _height = event.xconfigure.height;
 
-                    _wfb = listener.onResized(width, height);
+                    _wfb = _listener.onResized(_width, _height);
                     sendRepaintIfUIDirty();
                 }
                 break;
@@ -419,7 +362,7 @@ void handleEvents(ref XEvent event, X11Window theWindow) nothrow @nogc
                 int dx = newMouseX - lastMouseX;
                 int dy = newMouseY - lastMouseY;
 
-                listener.onMouseMove(newMouseX, newMouseY, dx, dy, mouseStateFromX11(event.xbutton.state));
+                _listener.onMouseMove(newMouseX, newMouseY, dx, dy, mouseStateFromX11(event.xbutton.state));
 
                 lastMouseX = newMouseX;
                 lastMouseY = newMouseY;
@@ -449,12 +392,12 @@ void handleEvents(ref XEvent event, X11Window theWindow) nothrow @nogc
 
                 if (event.xbutton.button == Button4 || event.xbutton.button == Button5)
                 {
-                    listener.onMouseWheel(newMouseX, newMouseY, 0, event.xbutton.button == Button4 ? 1 : -1,
+                    _listener.onMouseWheel(newMouseX, newMouseY, 0, event.xbutton.button == Button4 ? 1 : -1,
                         mouseStateFromX11(event.xbutton.state));
                 }
                 else
                 {
-                    listener.onMouseClick(newMouseX, newMouseY, button, isDoubleClick, mouseStateFromX11(event.xbutton.state));
+                    _listener.onMouseClick(newMouseX, newMouseY, button, isDoubleClick, mouseStateFromX11(event.xbutton.state));
                 }
                 break;
 
@@ -476,7 +419,7 @@ void handleEvents(ref XEvent event, X11Window theWindow) nothrow @nogc
                 else if (event.xbutton.button == Button4 || event.xbutton.button == Button5)
                     break;
 
-                listener.onMouseRelease(newMouseX, newMouseY, button, mouseStateFromX11(event.xbutton.state));
+                _listener.onMouseRelease(newMouseX, newMouseY, button, mouseStateFromX11(event.xbutton.state));
                 break;
 
             case DestroyNotify:
@@ -501,7 +444,7 @@ void handleEvents(ref XEvent event, X11Window theWindow) nothrow @nogc
                 break;
         }
     }
-    theWindow.drawMutex.unlock();
+    debug(logX11Window) printf("> handleEvents\n");
 }
 
 Key convertKeyFromX11(KeySym symbol)


### PR DESCRIPTION
This fixes a lot of the performance issues on Linux.  The distort example is much faster now.  I've removed the use of the graphicsMutex and rely on `XLockDisplay` and `XUnlockDisplay`.  Instead of reordering the data and swapping the buffers, the window now uses `_wfb.pixels` directly.