### PR TITLE
 Extend RingBufferNoGC

### DIFF
--- a/core/dplug/core/ringbuf.d
+++ b/core/dplug/core/ringbuf.d
@@ -138,22 +138,6 @@ struct RingBufferNoGC(T)
             return _data.ptr[(_first + index) % _data.length];
         }
 
-        /// Sets the item with the corresponding index in the queue to the passed value.
-        ///
-        /// Caution: Circumvents the purpose of a buffer.
-        void opIndexAssign(T value, size_t index)
-        {
-            // crash if index out-of-bounds (not recoverable)
-            version(D_NoBoundsChecks) {}
-            else
-            {
-                if (index >= _count)
-                    assert(0);
-            }
-
-            _data.ptr[(_first + index) % _data.length] = value;
-        }
-
         ///
         int opApply(scope int delegate(T) dg)
         {
@@ -209,11 +193,6 @@ unittest
         vec.pushBack(i);
     }
     assert(vec.releaseData() == [100, 300]);
-
-    rb[1] = 500;
-    rb[0] = 400;
-    assert(rb[0] == 400);
-    assert(rb[1] == 500);
 }
 
 /// Reusable mechanism to provide the UI with continuously available non-critical data from the audio thread.

--- a/core/dplug/core/ringbuf.d
+++ b/core/dplug/core/ringbuf.d
@@ -138,6 +138,22 @@ struct RingBufferNoGC(T)
             return _data.ptr[(_first + index) % _data.length];
         }
 
+        /// Sets the item with the corresponding index in the queue to the passed value.
+        ///
+        /// Caution: Circumvents the purpose of a buffer.
+        void opIndexAssign(T value, size_t index)
+        {
+            // crash if index out-of-bounds (not recoverable)
+            version(D_NoBoundsChecks) {}
+            else
+            {
+                if (index >= _count)
+                    assert(0);
+            }
+
+            _data.ptr[(_first + index) % _data.length] = value;
+        }
+
         ///
         int opApply(scope int delegate(T) dg)
         {
@@ -193,6 +209,11 @@ unittest
         vec.pushBack(i);
     }
     assert(vec.releaseData() == [100, 300]);
+
+    rb[1] = 500;
+    rb[0] = 400;
+    assert(rb[0] == 400);
+    assert(rb[1] == 500);
 }
 
 /// Reusable mechanism to provide the UI with continuously available non-critical data from the audio thread.

--- a/core/dplug/core/ringbuf.d
+++ b/core/dplug/core/ringbuf.d
@@ -128,8 +128,12 @@ struct RingBufferNoGC(T)
         T opIndex(size_t index) nothrow @nogc
         {
             // crash if index out-of-bounds (not recoverable)
-            if (index > _count)
-                assert(0);
+            version(D_NoBoundsChecks) {}
+            else
+            {
+                if (index >= _count)
+                    assert(0);
+            }
 
             return _data.ptr[(_first + index) % _data.length];
         }

--- a/core/dplug/core/ringbuf.d
+++ b/core/dplug/core/ringbuf.d
@@ -135,14 +135,13 @@ struct RingBufferNoGC(T)
         }
 
         ///
-        int opApply(scope int delegate(ref T) dg)
+        int opApply(scope int delegate(T) dg)
         {
             int result = 0;
 
             for (size_t i = 0; i < length(); i++)
             {
-                T x = this[i];
-                result = dg(x);
+                result = dg(this[i]);
                 if (result)
                     break;
             }

--- a/core/dplug/core/ringbuf.d
+++ b/core/dplug/core/ringbuf.d
@@ -12,8 +12,10 @@ import dplug.core.sync;
 import dplug.core.nogc;
 import dplug.core.vec;
 
+deprecated("Use makeRingBufferNoGC instead.") // unfortunately no warning because of https://issues.dlang.org/show_bug.cgi?id=19780
+alias ringBufferNoGC = makeRingBufferNoGC;
 
-RingBufferNoGC!T ringBufferNoGC(T)(size_t initialCapacity) nothrow @nogc
+RingBufferNoGC!T makeRingBufferNoGC(T)(size_t initialCapacity) nothrow @nogc
 {
     return RingBufferNoGC!T(initialCapacity);
 }


### PR DESCRIPTION
+ ```
  Implements:
   - bool empty()
   - opOpAssign!("~")
   - opApply	<-- foreach
  ```

+ renames `ringBufferNoGC` to `makeRingBufferNoGC` for consistency (see [`makeVec`](https://github.com/AuburnSounds/Dplug/blob/v8.3.5/core/dplug/core/vec.d#L251))