### PR TITLE
Add sample-meter example plugin

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3,6 +3,7 @@
    * `examples/clipit`: mandatory distortion plugin, with a flat UI
    * `examples/ms-encode`: simplest plugin for tutorial purpose, without UI
    * `examples/poly-alias-synth`: simple polyphonic wave generator, without UI
+   * `examples/sample-meter`: very simple logger using C runtime's file IO, without UI
    * `examples/simple-mono-synth`: very basic sine-wave generator, without UI
 
 

--- a/examples/sample-meter/README.md
+++ b/examples/sample-meter/README.md
@@ -1,0 +1,5 @@
+# Sample Meter
+
+Utility audio plugin to log number of samples ("frames") passed to `processAudio()`.
+
+Check the created `sample-meter.log` file.

--- a/examples/sample-meter/dub.json
+++ b/examples/sample-meter/dub.json
@@ -1,0 +1,40 @@
+{
+    "$schema": "https://raw.githubusercontent.com/Pure-D/code-d/master/json-validation/dub.schema.json",
+
+    "name": "sample-meter",
+
+    "importPaths": [ "." ],
+    "sourcePaths": [ "." ],
+    "stringImportPaths": [ "." ],
+
+    "targetType": "dynamicLibrary",
+
+    "lflags-windows-ldc": [
+        "libcmt.lib",
+        "/nodefaultlib:msvcrt.lib",
+        "/nodefaultlib:vcruntime.lib"
+    ],
+
+    "dflags-linux-dmd": ["-defaultlib=libphobos2.a"],
+
+    "dflags-osx-ldc": ["-static"],
+
+    "comment-WARNING-READ-THIS-IS-IMPORTANT": [
+        "    When making your own plug-in you have to CHANGE THESE DEPENDENCY    ",
+        "    SPECIFICATIONS below from path-based to ~>MAJOR.MINOR               ",
+        "      Example: ~>8.0                                                    ",
+        "    See also the DUB documentation:                                     ",
+        "         https://code.dlang.org/package-format?lang=json#version-specs  "],
+    "dependencies":
+    {
+        "dplug:vst": { "path": "../.." }
+    },
+
+    "configurations": [
+        {
+            "name": "VST",
+            "versions": ["VST"],
+            "targetType": "dynamicLibrary"
+        }
+    ]
+}

--- a/examples/sample-meter/plugin.d
+++ b/examples/sample-meter/plugin.d
@@ -1,0 +1,76 @@
+/**
+Copyright: Elias Batek (0xEAB) 2019.
+License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+*/
+import dplug.core, dplug.client;
+import core.stdc.stdio;
+
+// This define entry points for plugin formats,
+// depending on which version identifiers are defined.
+mixin(pluginEntryPoints!SampleMeter);
+
+final class SampleMeter : dplug.client.Client
+{
+nothrow @nogc:
+
+private:
+
+    FILE* _log;
+    int _previousFrames = -1; // -1 cannot occur in practice, so this makes a good default
+
+public:
+
+    this()
+    {
+        super();
+        this._log = fopen("sample-meter.log", "a");
+    }
+
+    ~this()
+    {
+        this._log.fclose();
+    }
+
+public override:
+
+    PluginInfo buildPluginInfo()
+    {
+        // Plugin info is parsed from plugin.json here at compile time.
+        // Indeed it is strongly recommended that you do not fill PluginInfo
+        // manually, else the information could diverge.
+        static immutable PluginInfo pluginInfo = parsePluginInfo(import("plugin.json"));
+        return pluginInfo;
+    }
+
+    Parameter[] buildParameters()
+    {
+        auto params = makeVec!Parameter();
+        return params.releaseData();
+    }
+
+    LegalIO[] buildLegalIO()
+    {
+        auto io = makeVec!LegalIO();
+        io.pushBack(LegalIO(2, 2));
+        return io.releaseData();
+    }
+
+    void reset(double sampleRate, int maxFrames, int numInputs, int numOutputs)
+    {
+    }
+
+    void processAudio(const(float*)[] inputs, float*[]outputs, int frames, TimeInfo)
+    {
+        // did frame-count change?
+        if (frames != this._previousFrames)
+        {
+            // yes
+            this._previousFrames = frames;
+            this._log.fprintf("%d\n", frames);
+            this._log.fflush();
+        }
+
+        outputs[0][0..frames] = inputs[0][0..frames];
+        outputs[1][0..frames] = inputs[1][0..frames];
+    }
+}

--- a/examples/sample-meter/plugin.json
+++ b/examples/sample-meter/plugin.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://raw.githubusercontent.com/AuburnSounds/dplug/master/plugin-schema.json",
+
+    "vendorName": "No Name Audio",
+    "vendorUniqueID": "NoAu",
+    "pluginName": "Sample Meter",
+    "pluginUniqueID": "Sp°",
+    "publicVersion": "1.0.0",
+    "CFBundleIdentifierPrefix": "om.nonameaudio",
+    "hasGUI": false,
+    "isSynth": false,
+    "receivesMIDI": false,
+    "category": "effectAnalysisAndMetering"
+}


### PR DESCRIPTION
Created for research purposes.
Not really special. Also not worth an own repository, but too good to delete imho.

#### Description
- very simple logger using C runtime's file IO, without UI
- Utility audio plugin to log number of samples ("frames") passed to `processAudio()`.