### PR TITLE
intialize runtime on all platforms

### DIFF
--- a/lv2/dplug/lv2/ttl.d
+++ b/lv2/dplug/lv2/ttl.d
@@ -42,17 +42,9 @@ void GenerateManifestFromClient_templated(alias ClientClass)(generateManifestFro
 {
     // Note: this function is called by D, so it reuses the runtime from dplug-build on Linux
     // FUTURE: make this function nothrow @nogc, to avoid relying on dplug-build runtime
-    version(Windows)
-    {
-        import core.runtime;
-        Runtime.initialize();
-    }
 
-    version(OSX)
-    {
-        import core.runtime;
-        Runtime.initialize();
-    }
+    import core.runtime;
+    Runtime.initialize();
 
     ClientClass client = mallocNew!ClientClass();
     scope(exit) client.destroyFree();


### PR DESCRIPTION
It turns out that it is necessary to initialize the runtime when building LV2 on linux also.  DMD works fine without this fix, but it is because DMD links against a shared runtime on linux currently while ldc links against a static runtime. 