### PR TITLE
dplug-build Windows Installer

### DIFF
--- a/tools/dplug-build/source/main.d
+++ b/tools/dplug-build/source/main.d
@@ -1064,6 +1064,16 @@ void generateWindowsInstaller(string outputDir,
             return "";
     }
 
+    string vstInstallDirDescription(bool is64b) pure
+    {
+        string description = "";
+        description ~= "Setup will install VST (";
+        description ~= is64b ? "64" : "32";
+        description ~= " bit) in the following folder.  To install in a different folder, ";
+        description ~= "click Browse and select another folder.  Click install to start the installation.";
+        return description;
+    }
+
     //remove ./ if it occurs at the beginning of windowsInstallerHeaderBmp
     string headerImagePage = plugin.windowsInstallerHeaderBmp.replaceAll(r"^./".regex, "");
     string nsisPath = "WindowsInstaller.nsi";
@@ -1129,6 +1139,7 @@ void generateWindowsInstaller(string outputDir,
             string formatNiceName = formatSectionDisplayName(p);
             content ~= "PageEx directory\n";
             content ~= "  PageCallbacks defaultInstDir" ~ identifer ~ ` "" getInstDir` ~ identifer ~ "\n";
+            content ~= "  DirText \"" ~ vstInstallDirDescription(p.is64b) ~ "\" \"\" \"\" \"\"\n";
             content ~= `  Caption ": ` ~ formatNiceName ~ ` Directory"` ~ "\n";
             content ~= "PageExEnd\n";
         }

--- a/tools/dplug-build/source/main.d
+++ b/tools/dplug-build/source/main.d
@@ -905,9 +905,38 @@ int main(string[] args)
         if (plugin.licensePath)
         {
             string licensePath = outputDir ~ "/license.html";
-            if (extension(plugin.licensePath) == ".html")
+            
+            bool convertToText = false;
+            version(Windows)
+            {
+                if (makeInstaller) {
+                    convertToText = true;
+                    licensePath = outputDir ~ "/license.txt";
+                }
+            }
+
+            if (extension(plugin.licensePath) == ".html" && convertToText)
+            {
+                // Convert license HTML file to text
+                cwritefln("*** Converting license file to TEXT... ".white);
+                string html = cast(string)std.file.read(plugin.licensePath);
+                string text = convertHTMLFileToText(html);
+                std.file.write(licensePath, text);
+                cwritefln(" => OK\n".green);
+            }
+            else if (extension(plugin.licensePath) == ".html")
             {
                 std.file.copy(plugin.licensePath, licensePath);
+            }
+            else if (extension(plugin.licensePath) == ".md" && convertToText)
+            {
+                // Convert license markdown to HTML and then text
+                cwritefln("*** Converting license file to TEXT... ".white);
+                string markdown = cast(string)std.file.read(plugin.licensePath);
+                string html = convertMarkdownFileToHTML(markdown);
+                string text = convertHTMLFileToText(html);
+                std.file.write(licensePath, text);
+                cwritefln(" => OK\n".green);
             }
             else if (extension(plugin.licensePath) == ".md")
             {

--- a/tools/dplug-build/source/main.d
+++ b/tools/dplug-build/source/main.d
@@ -1040,18 +1040,32 @@ void generateWindowsInstaller(string outputDir,
     import std.regex: regex, replaceAll;
     import std.array : array;
 
-    string headerImagePage = plugin.windowsInstallerHeaderBmp.replaceAll(r"^./".regex, "");
-
-    string formatSectionDisplayName(WindowsPackage pack)
+    string formatSectionDisplayName(WindowsPackage pack) pure
     {
         return format("%s %s", pack.format, pack.is64b ? "(64 bit)" : "(32 bit)");
     }
 
-    string formatSectionIdentifier(WindowsPackage pack)
+    string formatSectionIdentifier(WindowsPackage pack) pure
     {
         return format("%s%s", pack.format, pack.is64b ? "64b" : "32b");
     }
 
+    string sectionDescription(WindowsPackage pack) pure 
+    {
+        if (pack.format == "VST")
+            return "For VST 2.4 hosts like Live, FL Studio, Bitwig, Reason, etc. Includes both 32bit and 64bit components.";
+        else if(pack.format == "VST3")
+            return "For VST3 hosts like Cubase, Digital Performer, Wavelab., etc. Includes both 32bit and 64bit components.";
+        else if(pack.format == "AAX")
+            return "For Pro Tools 11 or later";
+        else if(pack.format == "LV2")
+            return "For LV2 hosts like Mixbus and Ardour";
+        else
+            return "";
+    }
+
+    //remove ./ if it occurs at the beginning of windowsInstallerHeaderBmp
+    string headerImagePage = plugin.windowsInstallerHeaderBmp.replaceAll(r"^./".regex, "");
     string nsisPath = "WindowsInstaller.nsi";
     string licensePath = plugin.licensePath;
 
@@ -1086,7 +1100,7 @@ void generateWindowsInstaller(string outputDir,
 
     foreach(p; sections)
     {
-        content ~= "LangString DESC_" ~ p.format ~ " ${LANG_ENGLISH} \"" ~ p.format ~ " Format\"\n";
+        content ~= "LangString DESC_" ~ p.format ~ " ${LANG_ENGLISH} \"" ~ sectionDescription(p) ~ "\"\n";
     }
 
     content ~= "!insertmacro MUI_FUNCTION_DESCRIPTION_BEGIN\n";

--- a/tools/dplug-build/source/main.d
+++ b/tools/dplug-build/source/main.d
@@ -1083,6 +1083,8 @@ void generateWindowsInstaller(string outputDir,
     string content = "";
 
     content ~= "!include \"MUI2.nsh\"\n";
+    content ~= "!include \"LogicLib.nsh\"\n";
+    content ~= "!include \"x64.nsh\"\n";
     content ~= `OutFile "` ~ outExePath ~ `"` ~ "\n\n";
 
     if (plugin.windowsInstallerHeaderBmp != null)
@@ -1156,10 +1158,10 @@ void generateWindowsInstaller(string outputDir,
     {
         if(p.format == "LV2")
         {
-            if(p.is64b)
+            if(!p.is64b)
             {
                 content ~= "  ${If} ${SectionIsSelected} ${Sec" ~ p.format ~ "}\n";
-                content ~= "    ${AndIf} ${RunningX64}\n";
+                content ~= "    ${AndIfNot} ${RunningX64}\n";
                 content ~= "      SetOutPath $InstDir" ~ formatSectionIdentifier(p) ~ "\n";
                 content ~= "      SetOutPath \"" ~ p.installDir ~ "\"\n";
                 content ~= "      File /r \"" ~ p.blobName ~ "\"\n";

--- a/tools/dplug-build/source/main.d
+++ b/tools/dplug-build/source/main.d
@@ -22,6 +22,11 @@ string MAC_AU_DIR  = "/Library/Audio/Plug-Ins/Components";
 string MAC_AAX_DIR = "/Library/Application Support/Avid/Audio/Plug-Ins";
 string MAC_LV2_DIR = "/Library/Audio/Plug-Ins/LV2";
 
+string WIN_VST3_DIR = "C:\\Program Files\\Common Files\\VST3";
+string WIN_VST_DIR = "C:\\Program Files\\VSTPlugins";
+string WIN_LV2_DIR = "%APPDATA%\\LV2";
+string WIN_AAX_DIR = "";
+
 void usage()
 {
     void flag(string arg, string desc, string possibleValues, string defaultDesc)
@@ -939,6 +944,36 @@ void buildPlugin(string compiler, string config, string build, bool is64b, bool 
         skipRegistry ? " --skip-registry=all" : ""
         );
     safeCommand(cmd);
+}
+
+struct WindowsPackage
+{
+    string pathToContents;
+    string blobName;
+    string title;
+}
+
+void generateWindowsInstaller(string outputDir,
+                              string resDir,
+                              Plugin plugin,
+                              WindowsPackage[] packs,
+                              string outExePath,
+                              bool verbose)
+{
+    string nsisPath = "makeInstaller.nsi";
+
+    string content = "";
+
+    content ~= `!include "MUI2.nsh"
+                !define MUI_ABORTWARNING
+                !insertmacro MUI_PAGE_LICENSE "${NSISDIR}\Docs\Modern UI\License.txt"
+                !insertmacro MUI_PAGE_COMPONENTS
+                !insertmacro MUI_UNPAGE_CONFIRM
+                !insertmacro MUI_UNPAGE_INSTFILES\n`;
+
+    content ~= `OutFile "` ~ outExePath ~ `"`;
+
+    std.file.write(nsisPath, cast(void[])content);
 }
 
 struct MacPackage

--- a/tools/dplug-build/source/main.d
+++ b/tools/dplug-build/source/main.d
@@ -603,7 +603,6 @@ int main(string[] args)
 
                     if(!isTemp && makeInstaller)
                     {
-                        string pathToContents;
                         string title;
                         string format;
                         string installDir;
@@ -640,7 +639,7 @@ int main(string[] args)
                             installDir = WIN_LV2_DIR;
                         }
                         
-                        windowsPackages ~= WindowsPackage(format, pathToContents, blobName, title, installDir, sizeInKiloBytes, arch == arch.x86_64);
+                        windowsPackages ~= WindowsPackage(format, blobName, title, installDir, sizeInKiloBytes, arch == arch.x86_64);
                     }
                 }
                 else version(linux)
@@ -966,7 +965,7 @@ int main(string[] args)
             {
                 cwriteln("*** Generating Windows installer...".white);
                 string windowsInstallerPath = outputDir ~ "/" ~ plugin.windowsInstallerName(configurations[0]);
-                generateWindowsInstaller(outputDir, resDir, plugin, windowsPackages, windowsInstallerPath, verbose);
+                generateWindowsInstaller(outputDir, plugin, windowsPackages, windowsInstallerPath, verbose);
                 cwriteln("    => OK".green);
                 cwriteln;
             }
@@ -1024,7 +1023,6 @@ void buildPlugin(string compiler, string config, string build, bool is64b, bool 
 struct WindowsPackage
 {
     string format;
-    string pathToContents;
     string blobName;
     string title;
     string installDir;
@@ -1033,7 +1031,6 @@ struct WindowsPackage
 }
 
 void generateWindowsInstaller(string outputDir,
-                              string resDir,
                               Plugin plugin,
                               WindowsPackage[] packs,
                               string outExePath,
@@ -1107,7 +1104,6 @@ void generateWindowsInstaller(string outputDir,
         }
     }
 
-    content ~= "Var PartName\n";
     content ~= "Name \"" ~ plugin.pluginName ~ " v" ~ plugin.publicVersionString ~ "\"\n\n";
 
     foreach(p; packs)
@@ -1135,7 +1131,6 @@ void generateWindowsInstaller(string outputDir,
             content ~= "    Abort\n";
             content ~= "  ${Else}\n";
             content ~= `    StrCpy $INSTDIR "` ~ p.installDir ~ `"` ~ "\n";
-            // content ~= `    StrCpy $PartName "` ~ p.title ~ `"` ~ "\n";
             content ~= "  ${EndIf}\n";
             content ~= "FunctionEnd\n\n";
             content ~= "Function getInstDir" ~ identifer ~ "\n";

--- a/tools/dplug-build/source/main.d
+++ b/tools/dplug-build/source/main.d
@@ -1189,16 +1189,12 @@ void generateWindowsInstaller(string outputDir,
     string makeNsiCommand = format("makensis.exe /V1 %s", nsisPath);
     safeCommand(makeNsiCommand);
 
-    // reusing fields already set in paceConfig to sign the output exe.
-    // TODO: move keyPassword-windows and keyFile-windows to plugin.json
-    auto paceConfig = plugin.paceConfig;
-
-    if(paceConfig.keyFileWindows !is null && paceConfig.keyPasswordWindows !is null)
+    if(plugin.keyFileWindows !is null && plugin.keyPasswordWindows !is null)
     {
         // use windows signtool to sign the installer for distribution
         string cmd = format("signtool sign /f %s /p %s /tr http://timestamp.comodoca.com/authenticode /td sha256 /fd sha256 /q %s", 
-                            paceConfig.keyFileWindows, 
-                            paceConfig.keyPasswordWindows,
+                            plugin.keyFileWindows, 
+                            plugin.keyPasswordWindows,
                             escapeShellArgument(outExePath));
         
         safeCommand(cmd);

--- a/tools/dplug-build/source/main.d
+++ b/tools/dplug-build/source/main.d
@@ -1157,7 +1157,7 @@ void generateWindowsInstaller(string outputDir,
     // TODO: move keyPassword-windows and keyFile-windows to plugin.json
     auto paceConfig = plugin.paceConfig;
 
-    string cmd = format("signtool sign /f %s /p %s /tr http://timestamp.comodoca.com  /td %s", 
+    string cmd = format("signtool sign /f %s /p %s /tr http://timestamp.comodoca.com/authenticode /td sha256 /fd sha256 /v %s", 
                         paceConfig.keyFileWindows, 
                         paceConfig.keyPasswordWindows,
                         outExePath);

--- a/tools/dplug-build/source/main.d
+++ b/tools/dplug-build/source/main.d
@@ -1085,6 +1085,7 @@ void generateWindowsInstaller(string outputDir,
     content ~= "!include \"LogicLib.nsh\"\n";
     content ~= "!include \"x64.nsh\"\n";
     content ~= "BrandingText \"" ~ plugin.vendorName ~ "\"\n";
+    content ~= "SpaceTexts none\n";
     content ~= `OutFile "` ~ outExePath ~ `"` ~ "\n\n";
 
     if (plugin.windowsInstallerHeaderBmp != null)

--- a/tools/dplug-build/source/plugin.d
+++ b/tools/dplug-build/source/plugin.d
@@ -386,6 +386,21 @@ struct Plugin
         }
     }
 
+    version(Windows)
+    {
+        string windowsInstallerName(string config) pure const
+        {
+            string verName = stripConfig(config);
+            if(verName)
+                verName = "-" ~ verName;
+            else
+                verName = "";
+            return format("%s%s-%s.exe", sanitizeFilenameString(pluginName),
+                                         verName,
+                                         publicVersionString);
+        }
+    }
+
     string getLV2PrettyName()
     {
         // Note: Carla doesn't support IRI with escaped character, so we have to remove

--- a/tools/dplug-build/source/plugin.d
+++ b/tools/dplug-build/source/plugin.d
@@ -162,7 +162,16 @@ struct Plugin
     // relative path to a .png for the Mac installer
     string installerPNGPath;
 
+    // relative path to .bmp image for Windows installer header
     string windowsInstallerHeaderBmp;
+
+    // WIndows-only, points to a .p12/.pfx certificate...
+    // duplicate key in pace.json
+    string keyFileWindows;
+
+    // ...and the password of its private key
+    // duplicate key in pace.json
+    string keyPasswordWindows;
 
 
     bool receivesMIDI;
@@ -620,11 +629,29 @@ Plugin readPluginDescription()
 
     try
     {
+        result.keyFileWindows = rawPluginFile["keyFile-windows"].str;
+    }
+    catch(Exception e)
+    {
+        result.keyFileWindows = null;
+    }
+
+    try
+    {
+        result.keyPasswordWindows = rawPluginFile["keyPassword-windows"].str;
+    }
+    catch(Exception e)
+    {
+        result.keyPasswordWindows = null;
+    }
+
+    try
+    {
         result.iconPath = rawPluginFile["iconPath"].str;
     }
     catch(Exception e)
     {
-        //info("Missing \"iconPath\" in plugin.json (eg: \"gfx/myIcon.png\")");
+        info("Missing \"iconPath\" in plugin.json (eg: \"gfx/myIcon.ico\")");
     }
 
     // Mandatory keys, but with workarounds

--- a/tools/dplug-build/source/plugin.d
+++ b/tools/dplug-build/source/plugin.d
@@ -162,6 +162,8 @@ struct Plugin
     // relative path to a .png for the Mac installer
     string installerPNGPath;
 
+    string windowsInstallerHeaderBmp;
+
 
     bool receivesMIDI;
     bool isSynth;
@@ -605,6 +607,15 @@ Plugin readPluginDescription()
     catch(Exception e)
     {
         result.installerPNGPath = null;
+    }
+
+    try
+    {
+        result.windowsInstallerHeaderBmp = rawPluginFile["windowsInstallerHeaderBmp"].str;
+    }
+    catch(Exception e)
+    {
+        result.windowsInstallerHeaderBmp = null;
     }
 
     try

--- a/tools/dplug-build/source/utils.d
+++ b/tools/dplug-build/source/utils.d
@@ -78,12 +78,6 @@ string convertMarkdownFileToHTML(string markdownFile)
     return res;
 }
 
-string convertHTMLFileToText(string htmlFile)
-{
-    import std.regex;
-    return replaceAll(htmlFile, r"<[^>]*>".regex, "");
-}
-
 void safeCommand(string cmd)
 {
     cwritefln("$ %s".cyan, cmd);

--- a/tools/dplug-build/source/utils.d
+++ b/tools/dplug-build/source/utils.d
@@ -78,6 +78,12 @@ string convertMarkdownFileToHTML(string markdownFile)
     return res;
 }
 
+string convertHTMLFileToText(string htmlFile)
+{
+    import std.regex;
+    return replaceAll(htmlFile, r"<[^>]*>".regex, "");
+}
+
 void safeCommand(string cmd)
 {
     cwritefln("$ %s".cyan, cmd);


### PR DESCRIPTION
This adds support for the `--installer` flag in `dplug-build` on Windows.

## Requirements
- Windows 10 SDK (must append path to `signtool.exe` to PATH variable)
- NSIS (must append path to `makensis.exe` to PATH variable)

## Features
- works with all current plugin formats
- Ability for user to choose which "Components" to install
- Ability for user to set install directory for VST 32bit and VST 64bit 
- Uses `signtool` from the Windows SDK to sign the resulting `.exe`
- custom header bmp image

## plugin.json additions
The windows installer uses the following fields in `plugin.json`

`windowsInstallerHeaderBmp` - optional 150x57 bmp image to use in the header

`keyFile-windows` - Path to PFX keyfile. Duplicated from pace.json

`keyPassword-windows` - Password for PFX keyfile. Duplicated from pace.json

Looking forward to review!