### PR TITLE
fix use of iconPath when should be iconPathWindows

### DIFF
--- a/tools/dplug-build/source/main.d
+++ b/tools/dplug-build/source/main.d
@@ -1102,8 +1102,8 @@ void generateWindowsInstaller(string outputDir,
     }
 
     content ~= "!define MUI_ABORTWARNING\n";
-    if (plugin.iconPath)
-        content ~= "!define MUI_ICON \"" ~ escapeNSISPath(plugin.iconPath) ~ "\"\n";
+    if (plugin.iconPathWindows)
+        content ~= "!define MUI_ICON \"" ~ escapeNSISPath(plugin.iconPathWindows) ~ "\"\n";
     content ~= "!insertmacro MUI_PAGE_LICENSE \"" ~ licensePath ~ "\"\n";
     content ~= "!insertmacro MUI_PAGE_COMPONENTS\n";
     content ~= "!insertmacro MUI_LANGUAGE \"English\"\n\n";


### PR DESCRIPTION
This was a silly mistake that got through when rebasing.
Note-to-self: verify it still builds after rebasing!