### PR TITLE
Use docker container for linux CI builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,14 +65,12 @@ jobs:
         ldc2 --version
         dub --version
 
-        # Install dplug-build
-        git clone --depth 1 https://github.com/AuburnSounds/Dplug dplug
-        cd dplug/tools/dplug-build
-        dub build
-        sudo ln -sf $(pwd)/dplug-build /usr/bin/dplug-build
+        # Pull dplug docker container
+        docker pull ctrecordings/dplug:latest
 
         # Install process
-        cd ../process
+        git clone --depth 1 https://github.com/AuburnSounds/Dplug dplug
+        cd dplug/tools/process
         dub build
         sudo ln -sf $(pwd)/process /usr/bin/process
       displayName: Install
@@ -84,12 +82,10 @@ jobs:
         export VST2_SDK="$(pwd)/VST2_SDK"
 
         # Here you can customize the flags, or build multiple plugins
-        cd examples/distort
-        dplug-build --no-color -c VST -c VST3 -c LV2 
-        cd ../..
-        cd examples/clipit
-        dplug-build --no-color -c VST -c VST3 -c LV2 
-        cd ../..
+        docker run -w /src/examples/distort --volume "$(pwd)/VST2_SDK:/VST2_SDK" --volume "$(pwd):/src" ctrecordings/dplug --no-color -c VST -c VST3 -c LV2 --compiler ldc2
+
+        docker run -w /src/examples/clipit --volume "$(pwd)/VST2_SDK:/VST2_SDK" --volume "$(pwd):/src" ctrecordings/dplug --no-color -c VST -c VST3 -c LV2 --compiler ldc2
+
       displayName: Build plug-ins
 
     - script: |


### PR DESCRIPTION
Fixes #406 

I've built a docker container that can be found at [Docker Hub](https://cloud.docker.com/u/ctrecordings/repository/docker/ctrecordings/dplug)

The container is based on the ubuntu:16.04 image (glibc v2.23) and has ldc v1.17 and dplug-build v9.0.9 installed.  The container has been made in a way that allows attaching the vst2 sdk directory and build directory as volumes.

This change pulls the container in the `Install` phase for linux and then uses the container to build the examples in the `Build plug-ins` phase.

I've verified that the builds succeed and have also tested the distort example on avlinux.

Using this container may also fix some of the other linux issues such as #401 but time will tell.