### PR TITLE
check for 239 error code from 'xcrun altool --notarization-info'

### DIFF
--- a/tools/dplug-build/source/main.d
+++ b/tools/dplug-build/source/main.d
@@ -1426,7 +1426,23 @@ void notarizeMacInstaller(Plugin plugin, string outPkgPath, string primaryBundle
                         plugin.appSpecificPassword_altool,
                         pollXMLPath,
                         );
-        safeCommand(cmd);
+
+        int errorCode = 239;
+        int retryAttempts = 0;
+        do
+        {
+            errorCode = unsafeCommand(cmd);
+            if(errorCode == 239)
+            {
+                cwritefln("    Notarization-info not yet available, retrying...".yellow);
+            }
+            else if (errorCode > 0)
+            {
+                throw new ExternalProgramErrored(errorCode, format("Command '%s' returned %s", cmd, errorCode));
+            }
+            ++retryAttempts;
+        }
+        while (errorCode == 239 && retryAttempts < 20);
 
         auto doc = new Document();
         doc.parseUtf8( cast(string)(std.file.read(pollXMLPath)), false, false);

--- a/tools/dplug-build/source/utils.d
+++ b/tools/dplug-build/source/utils.d
@@ -95,6 +95,14 @@ void safeCommand(string cmd)
         throw new ExternalProgramErrored(errorCode, format("Command '%s' returned %s", cmd, errorCode));
 }
 
+int unsafeCommand(string cmd)
+{
+    cwritefln("$ %s".cyan, cmd);
+    auto pid = spawnShell(cmd);
+    auto errorCode = wait(pid);
+    return errorCode;
+}
+
 string escapeXMLString(string s)
 {
     s = s.replace("&", "&amp;");


### PR DESCRIPTION
It seems that sometimes while notarizing, the notarization info isn't immediately available which causes `xcrun altool --notarization-info` to fail.  This PR adds a check for error code 239 and will retry as many as 20 times while receiving this error code.

In my initial test it retried 7 times before receiving a succes error code and then continued to finish the rest of the build correctly.

Fixes #412 