### PR TITLE
fix left over StackAllocState reference

### DIFF
--- a/core/dplug/core/stackallocator.d
+++ b/core/dplug/core/stackallocator.d
@@ -36,7 +36,7 @@ public:
     /// Save allocation state
     State saveState()
     {
-        return StackAllocState(numUsedPages, currentPageFreeBytes);
+        return State(numUsedPages, currentPageFreeBytes);
     }
 
     /// Pop allocation state


### PR DESCRIPTION
A reference to StackAllocState slipped through the cracks.  This should fix the failing builds.