### PR TITLE
Allow UIElements to specify mouse cursor state when in dragged or mouse-over state.

### DIFF
--- a/gui/dplug/gui/context.d
+++ b/gui/dplug/gui/context.d
@@ -104,6 +104,27 @@ nothrow:
             dragged = null;
         }
     }
+
+    final MouseCursor getCurrentMouseCursor() nothrow @nogc
+    {
+        MouseCursor cursor = MouseCursor.pointer;
+
+        version(legacyMouseOver) { cursor = MouseCursor.pointer;}
+        else
+        {
+            if (!(mouseOver is null))
+            {
+                cursor = mouseOver.CursorWhenMouseOver;
+            }
+        }
+
+        if(!(dragged is null))
+        {
+            cursor = dragged.CursorWhenDragged;
+        }        
+
+        return cursor;
+    }
 }
 
 DirtyRectList makeDirtyRectList() nothrow @nogc

--- a/gui/dplug/gui/element.d
+++ b/gui/dplug/gui/element.d
@@ -97,6 +97,8 @@ nothrow:
         _localRectsBuf = makeVec!box2i();
         _children = makeVec!UIElement();
         _zOrderedChildren = makeVec!UIElement();
+        _cursorWhenDragged = MouseCursor.pointer;
+        _cursorWhenMouseOver = MouseCursor.pointer;
     }
 
     ~this()
@@ -784,6 +786,12 @@ nothrow:
         }
     }
 
+    @property MouseCursor CursorWhenDragged() { return _cursorWhenDragged; }
+    @property MouseCursor CursorWhenDragged(MouseCursor value) { return _cursorWhenDragged = value; }
+
+    @property MouseCursor CursorWhenMouseOver() { return _cursorWhenMouseOver; }
+    @property MouseCursor CursorWhenMouseOver(MouseCursor value) { return _cursorWhenMouseOver = value; }
+
 protected:
 
     /// Raw layer draw method. This gives you 1 surface cropped by  _position for drawing.
@@ -881,6 +889,9 @@ private:
 
     /// Sorted children in Z-lexical-order (sorted by Z, or else increasing index in _children).
     Vec!UIElement _zOrderedChildren;
+
+    MouseCursor _cursorWhenDragged;
+    MouseCursor _cursorWhenMouseOver;
 
     // Sort children in ascending z-order
     // Input: unsorted _children

--- a/gui/dplug/gui/graphics.d
+++ b/gui/dplug/gui/graphics.d
@@ -298,6 +298,11 @@ nothrow:
         {
             outer.animate(dt, time);
         }
+
+        override MouseCursor getMouseCursor()
+        {
+            return outer._uiContext.getCurrentMouseCursor();
+        }
     }
 
     /// Tune this to tune the trade-off between light quality and speed.

--- a/pbrwidgets/dplug/pbrwidgets/imageknob.d
+++ b/pbrwidgets/dplug/pbrwidgets/imageknob.d
@@ -20,6 +20,7 @@ import dplug.graphics.color;
 import dplug.graphics.image;
 import dplug.graphics.draw;
 import dplug.graphics.drawex;
+import dplug.gui.element;
 
 nothrow:
 @nogc:
@@ -109,6 +110,8 @@ nothrow:
     {
         super(context, parameter);
         _knobImage = knobImage;
+        CursorWhenDragged = MouseCursor.drag;
+        CursorWhenMouseOver = MouseCursor.drag;
     }
 
     override void drawKnob(ImageRef!RGBA diffuseMap, ImageRef!L16 depthMap, ImageRef!RGBA materialMap, box2i[] dirtyRects)

--- a/pbrwidgets/dplug/pbrwidgets/knob.d
+++ b/pbrwidgets/dplug/pbrwidgets/knob.d
@@ -86,6 +86,8 @@ nothrow:
         _param.addListener(this);
         _pushedAnimation = 0;
         clearCrosspoints();
+        CursorWhenDragged = MouseCursor.drag;
+        CursorWhenMouseOver = MouseCursor.move;
     }
 
     ~this()

--- a/pbrwidgets/dplug/pbrwidgets/label.d
+++ b/pbrwidgets/dplug/pbrwidgets/label.d
@@ -27,6 +27,7 @@ nothrow:
         super(context, flagAnimated | flagPBR);
         _text = text;
         _font = font;
+        CursorWhenMouseOver = MouseCursor.linkSelect;
     }
 
     /// Returns: Font used.

--- a/pbrwidgets/dplug/pbrwidgets/slider.d
+++ b/pbrwidgets/dplug/pbrwidgets/slider.d
@@ -55,6 +55,8 @@ nothrow:
         _sensivity = 1.0f;
          _pushedAnimation = 0;
         clearCrosspoints();
+        CursorWhenDragged = MouseCursor.drag;
+        CursorWhenMouseOver = MouseCursor.move;
     }
 
     ~this()

--- a/window/dplug/window/window.d
+++ b/window/dplug/window/window.d
@@ -72,6 +72,17 @@ struct MouseState
     bool altPressed;
 }
 
+enum MouseCursor
+{
+    pointer, //default cursor
+    linkSelect,
+    move,
+    drag,
+    verticalResize,
+    horizontalResize,
+    hidden
+}
+
 /// Is this window intended as a plug-in window running inside a host,
 /// or a host window itself possibly hosting a plug-in?
 enum WindowUsage
@@ -206,6 +217,9 @@ nothrow @nogc:
     /// `time` must refer to the window creation time.
     /// `dt` and `time` are expressed in seconds (not milliseconds).
     void onAnimate(double dt, double time);
+
+    /// Must be called to get the current mouse cursor state for the plugin
+    MouseCursor getMouseCursor();
 }
 
 /// Various backends for windowing.


### PR DESCRIPTION
This isnt ready for merge yet.  I wanted to go ahead and open this PR to discuss it.

`UIElement` now has two properties `CursorWhenDragged` and `CursorWhenMouseOver`.  

These are retrieved by the UIContext using the `getCurrentMouseCursor` method.  This method prioritizes the element that is being dragged.  If no element is being dragged, it looks for the element being moused over, lastly if it will default to the `MouseCursor.pointer`.

The  MouseCursor enum can easily be changed to use different names, or to add/remove possible cursor types we might want.  Any thoughts on this?
```D
enum MouseCursor
{
    pointer, //default cursor
    linkSelect,
    move,
    drag,
    verticalResize,
    horizontalResize,
    hidden
}
```

Currently `X11Window` is working.  I still have to add the changes necessary for win32 and cocoa.