### PR TITLE
Resizable UIs

### DIFF
--- a/au/dplug/au/client.d
+++ b/au/dplug/au/client.d
@@ -2208,7 +2208,7 @@ private:
 
         override bool requestResize(int width, int height)
         {
-            return false; // FUTURE implement for AU
+            return true; // FUTURE implement for AU
         }
 
         DAW _daw = DAW.Unknown;

--- a/client/dplug/client/graphics.d
+++ b/client/dplug/client/graphics.d
@@ -28,5 +28,6 @@ nothrow:
     abstract void* openUI(void* parentInfo, void* controlInfo, DAW daw, GraphicsBackend backend);
     abstract void closeUI();
     abstract void getGUISize(int* width, int* height);
+    abstract void resizeWindow(int width, int height);
 }
 

--- a/cocoa/derelict/cocoa/appkit.d
+++ b/cocoa/derelict/cocoa/appkit.d
@@ -214,11 +214,6 @@ nothrow @nogc:
 
     void setFrameSize(NSSize newSize)
     {
-        version(Debug)
-        {
-            import core.stdc.stdlib;
-            fprintf(stderr, "this is a test");
-        }
         alias fun_t = extern(C) void function (id, SEL, NSSize) nothrow @nogc;
         (cast(fun_t)objc_msgSend)(_id, sel!"setFrameSize:", newSize);
     }

--- a/cocoa/derelict/cocoa/appkit.d
+++ b/cocoa/derelict/cocoa/appkit.d
@@ -163,6 +163,18 @@ nothrow @nogc:
         (cast(fun_t)objc_msgSend)(_id, sel!"setNeedsDisplayInRect:", rect);
     }
 
+    void display()
+    {
+        alias fun_t = extern(C) void function (id, SEL) nothrow @nogc;
+        (cast(fun_t)objc_msgSend)(_id, sel!"display");
+    }
+
+    void setNeedsDisplay()
+    {
+        alias fun_t = extern(C) void function (id, SEL) nothrow @nogc;
+        (cast(fun_t)objc_msgSend)(_id, sel!"setNeedsDisplay:");
+    }
+
     NSPoint convertPoint(NSPoint point, NSView view)
     {
         alias fun_t = extern(C) NSPoint function (id, const(SEL), NSPoint, id) nothrow @nogc;
@@ -198,6 +210,17 @@ nothrow @nogc:
     {
         alias fun_t = extern(C) void function (id, SEL, BOOL) nothrow @nogc;
         (cast(fun_t)objc_msgSend)(_id, sel!"setWantsLayer:", value);
+    }
+
+    void setFrameSize(NSSize newSize)
+    {
+        version(Debug)
+        {
+            import core.stdc.stdlib;
+            fprintf(stderr, "this is a test");
+        }
+        alias fun_t = extern(C) void function (id, SEL, NSSize) nothrow @nogc;
+        (cast(fun_t)objc_msgSend)(_id, sel!"setFrameSize:", newSize);
     }
 }
 
@@ -303,6 +326,12 @@ nothrow @nogc:
     {
         alias fun_t = extern(C) void function (id, SEL, BOOL) nothrow @nogc;
         (cast(fun_t)objc_msgSend)(_id, sel!"setAcceptsMouseMovedEvents:", b ? YES : NO);
+    }
+
+    void setFrameDisplay(NSRect frameRect, bool display)
+    {
+        alias fun_t = extern(C) void function(id, SEL, NSRect, BOOL) nothrow @nogc;
+        (cast(fun_t)objc_msgSend)(_id, sel!"setFrameDisplay", frameRect, display ? YES : NO);
     }
 }
 

--- a/examples/clipit/gui.d
+++ b/examples/clipit/gui.d
@@ -31,7 +31,7 @@ nothrow:
     this(ClipitClient client)
     {
         _client = client;
-        super(_initialWidth, _initialHeight); // size
+        super(_initialWidth, _initialHeight, _client); // size
 
         // Sets the number of pixels recomputed around dirtied controls.
         // Since we aren't using pbr we can set this value to 0 to save
@@ -67,25 +67,25 @@ nothrow:
     {
         super.onDrawRaw(rawMap,dirtyRects);
 
-        foreach(dirtyRect; dirtyRects)
-        {
-            auto cRaw = rawMap.cropImageRef(dirtyRect);
-            canvas.initialize(cRaw);
-            canvas.translate(-dirtyRect.min.x, -dirtyRect.min.y);
+        // foreach(dirtyRect; dirtyRects)
+        // {
+        //     auto cRaw = rawMap.cropImageRef(dirtyRect);
+        //     canvas.initialize(cRaw);
+        //     canvas.translate(-dirtyRect.min.x, -dirtyRect.min.y);
 
-            // gradients have to be recreated for each dirtyRect
-            auto gradient = canvas.createLinearGradient(0, 0, 100*1.414, 100*1.414);
-            gradient.addColorStop(0.0f, RGBA(255, 50, 128, 255));
-            gradient.addColorStop(1.0f, RGBA(128, 128, 128, 0));
+        //     // gradients have to be recreated for each dirtyRect
+        //     auto gradient = canvas.createLinearGradient(0, 0, 100*1.414, 100*1.414);
+        //     gradient.addColorStop(0.0f, RGBA(255, 50, 128, 255));
+        //     gradient.addColorStop(1.0f, RGBA(128, 128, 128, 0));
 
-            canvas.fillStyle = gradient;
+        //     canvas.fillStyle = gradient;
 
-            canvas.beginPath;
-                canvas.moveTo(0, 0);
-                canvas.lineTo(200, 0);
-                canvas.lineTo(0, 200);
-                canvas.fill();
-        }
+        //     canvas.beginPath;
+        //         canvas.moveTo(0, 0);
+        //         canvas.lineTo(200, 0);
+        //         canvas.lineTo(0, 200);
+        //         canvas.fill();
+        // }
 
     }
 
@@ -124,15 +124,15 @@ nothrow:
     {
         if(isDoubleClick)
         {
-            if(_position.width == 1000)
+            if(_position.width == cast(int)(_initialWidth * 0.5))
             {
-                _client.hostCommand().requestResize(_initialWidth, _initialHeight);
                 resizeWindow(_initialWidth, _initialHeight);
             }
             else
             {
-                _client.hostCommand().requestResize(_initialWidth * 2, _initialHeight * 2);
-                resizeWindow(_initialWidth * 2, _initialHeight * 2);
+                int newWidth = cast(int)(_initialWidth * 0.5);
+                int newHeight = cast(int)(_initialHeight * 0.5);
+                resizeWindow(newWidth, newHeight);
             }
             return true;
         }

--- a/examples/clipit/gui.d
+++ b/examples/clipit/gui.d
@@ -126,11 +126,11 @@ nothrow:
         {
             if(_position.width == 1000)
             {
-                _client.hostCommand().requestResize(_initialWidth, _initialHeight);
+                resizeWindow(_initialWidth, _initialHeight);
             }
             else
             {
-                _client.hostCommand().requestResize(_initialWidth * 2, _initialHeight * 2);
+                resizeWindow(_initialWidth * 2, _initialHeight * 2);
             }
             return true;
         }

--- a/examples/clipit/gui.d
+++ b/examples/clipit/gui.d
@@ -126,10 +126,12 @@ nothrow:
         {
             if(_position.width == 1000)
             {
+                _client.hostCommand().requestResize(_initialWidth, _initialHeight);
                 resizeWindow(_initialWidth, _initialHeight);
             }
             else
             {
+                _client.hostCommand().requestResize(_initialWidth * 2, _initialHeight * 2);
                 resizeWindow(_initialWidth * 2, _initialHeight * 2);
             }
             return true;

--- a/examples/distort/gui.d
+++ b/examples/distort/gui.d
@@ -163,10 +163,12 @@ nothrow:
         {
             if(_position.width == _initialHeight * 2)
             {
+                _client.hostCommand().requestResize(_initialWidth, _initialHeight);
                 resizeWindow(_initialWidth, _initialHeight);
             }
             else
             {
+                _client.hostCommand().requestResize(_initialWidth * 2, _initialHeight * 2);
                 resizeWindow(_initialWidth * 2, _initialHeight * 2);
             }
             return true;

--- a/examples/distort/gui.d
+++ b/examples/distort/gui.d
@@ -136,6 +136,12 @@ nothrow:
             colorCorrection.setLiftGammaGainContrastRGB(colorCorrectionMatrix);
             colorCorrection.position = box2i.rectangle(0, 0, W, H);
         }
+         _client.hostCommand().requestResize(W * 2, H *2);
+    }
+
+    override void reflow(box2i availableSpace)
+    {
+        _position = availableSpace;
     }
 
     ~this()

--- a/examples/distort/gui.d
+++ b/examples/distort/gui.d
@@ -43,8 +43,7 @@ nothrow:
     this(DistortClient client)
     {
         _client = client;
-        int W = 620, H = 330;
-        super(W, H); // size
+        super(_initialWidth, _initialHeight); // size
 
 
         // Note: PBRCompositor default lighting might change in a future version (increase of light to allow white plastics).
@@ -74,53 +73,32 @@ nothrow:
         // to move into a reflow() override.
         // Meanwhile, we hardcode each position.
 
-        RGBA litTrailDiffuse = RGBA(151, 119, 255, 100);
-        RGBA unlitTrailDiffuse = RGBA(81, 54, 108, 0);
-
         KnobImage _knobImageData;
-        UIImageKnob _imageKnob;
 
         _knobImageData = loadKnobImage( import("imageknob.png") );
         addChild(_imageKnob = mallocNew!UIImageKnob(context(), _knobImageData, cast(FloatParameter) _client.param(paramBias)));
-        _imageKnob.position = rectangle(517, 176, 46, 46);
-        _imageKnob.hasTrail = false; // no trail by default
+
 
         // Add procedural knobs
         addChild(driveKnob = mallocNew!UIKnob(context(), cast(FloatParameter) _client.param(paramDrive)));
-        driveKnob.position = box2i.rectangle(250, 140, 120, 120);
-        driveKnob.knobRadius = 0.65f;
-        driveKnob.knobDiffuse = RGBA(255, 255, 238, 0);
-        driveKnob.knobMaterial = RGBA(0, 255, 128, 255);
-        driveKnob.numLEDs = 15;
-        driveKnob.litTrailDiffuse = litTrailDiffuse;
-        driveKnob.unlitTrailDiffuse = unlitTrailDiffuse;
-        driveKnob.LEDDiffuseLit = RGBA(40, 40, 40, 100);
-        driveKnob.LEDDiffuseUnlit = RGBA(40, 40, 40, 0);
-        driveKnob.LEDRadiusMin = 0.06f;
-        driveKnob.LEDRadiusMax = 0.06f;
+
 
         // Add sliders
         addChild(inputSlider = mallocNew!UISlider(context(), cast(FloatParameter) _client.param(paramInput)));
-        inputSlider.position = box2i.rectangle(190, 132, 30, 130);
-        inputSlider.litTrailDiffuse = litTrailDiffuse;
-        inputSlider.unlitTrailDiffuse = unlitTrailDiffuse;
+        
 
         addChild(outputSlider = mallocNew!UISlider(context(), cast(FloatParameter) _client.param(paramOutput)));
-        outputSlider.position = box2i.rectangle(410, 132, 30, 130);
-        outputSlider.litTrailDiffuse = litTrailDiffuse;
-        outputSlider.unlitTrailDiffuse = unlitTrailDiffuse;
+        
 
         // Add switch
         addChild(onOffSwitch = mallocNew!UIOnOffSwitch(context(), cast(BoolParameter) _client.param(paramOnOff)));
-        onOffSwitch.position = box2i.rectangle(90, 177, 30, 40);
-        onOffSwitch.diffuseOn = litTrailDiffuse;
-        onOffSwitch.diffuseOff = unlitTrailDiffuse;
+        
 
         // Add bargraphs
         addChild(inputBargraph = mallocNew!UIBargraph(context(), 2, -80.0f, 6.0f));
-        inputBargraph.position = box2i.rectangle(150, 132, 30, 130);
+        
         addChild(outputBargraph = mallocNew!UIBargraph(context(), 2, -80.0f, 6.0f));
-        outputBargraph.position = box2i.rectangle(450, 132, 30, 130);
+        
         static immutable float[2] startValues = [0.0f, 0.0f];
         inputBargraph.setValues(startValues);
         outputBargraph.setValues(startValues);
@@ -134,19 +112,84 @@ nothrow:
                                                               + 0.0f , 1.0f , 1.10f, -0.01f);
             addChild(colorCorrection = mallocNew!UIColorCorrection(context()));
             colorCorrection.setLiftGammaGainContrastRGB(colorCorrectionMatrix);
-            colorCorrection.position = box2i.rectangle(0, 0, W, H);
         }
-         _client.hostCommand().requestResize(W * 2, H *2);
     }
 
     override void reflow(box2i availableSpace)
     {
-        _position = availableSpace;
+        super.reflow(availableSpace);
+
+        RGBA litTrailDiffuse = RGBA(151, 119, 255, 100);
+        RGBA unlitTrailDiffuse = RGBA(81, 54, 108, 0);
+
+        _imageKnob.position = box2i.rectangle(relativeWidth(517), relativeHeight(176), relativeWidth(46), relativeHeight(46));
+        _imageKnob.hasTrail = false; // no trail by default
+
+        driveKnob.position = box2i.rectangle(relativeWidth(250), relativeHeight(140), relativeWidth(120), relativeHeight(120));
+        driveKnob.knobRadius = 0.65f;
+        driveKnob.knobDiffuse = RGBA(255, 255, 238, 0);
+        driveKnob.knobMaterial = RGBA(0, 255, 128, 255);
+        driveKnob.numLEDs = 15;
+        driveKnob.litTrailDiffuse = litTrailDiffuse;
+        driveKnob.unlitTrailDiffuse = unlitTrailDiffuse;
+        driveKnob.LEDDiffuseLit = RGBA(40, 40, 40, 100);
+        driveKnob.LEDDiffuseUnlit = RGBA(40, 40, 40, 0);
+        driveKnob.LEDRadiusMin = 0.06f;
+        driveKnob.LEDRadiusMax = 0.06f;
+
+        inputSlider.position = box2i.rectangle(relativeWidth(190), relativeHeight(132), relativeWidth(30), relativeHeight(130));
+        inputSlider.litTrailDiffuse = litTrailDiffuse;
+        inputSlider.unlitTrailDiffuse = unlitTrailDiffuse;
+
+        outputSlider.position = box2i.rectangle(relativeWidth(410), relativeHeight(132), relativeWidth(30), relativeHeight(130));
+        outputSlider.litTrailDiffuse = litTrailDiffuse;
+        outputSlider.unlitTrailDiffuse = unlitTrailDiffuse;
+
+        onOffSwitch.position = box2i.rectangle(relativeWidth(90), relativeHeight(177), relativeWidth(30), relativeHeight(40));
+        onOffSwitch.diffuseOn = litTrailDiffuse;
+        onOffSwitch.diffuseOff = unlitTrailDiffuse;
+
+        inputBargraph.position = box2i.rectangle(relativeWidth(150), relativeHeight(132), relativeWidth(30), relativeHeight(130));
+
+        outputBargraph.position = box2i.rectangle(relativeWidth(450), relativeHeight(132), relativeWidth(30), relativeHeight(130));
+
+        colorCorrection.position = box2i.rectangle(0, 0, _position.width, _position.height);
+    }
+
+    /// This on only a temporary addition for testing the resizing ability of dplug
+    override bool onMouseClick(int x, int y, int button, bool isDoubleClick, MouseState mstate)
+    {
+        if(isDoubleClick)
+        {
+            if(_position.width == _initialHeight * 2)
+            {
+                _client.hostCommand().requestResize(_initialWidth, _initialHeight);
+            }
+            else
+            {
+                _client.hostCommand().requestResize(_initialWidth * 2, _initialHeight * 2);
+            }
+            return true;
+        }
+        return false;
     }
 
     ~this()
     {
         _font.destroyFree();
         _knobImageData.destroyFree();        
+    }
+
+private:
+    int _initialWidth = 620, _initialHeight = 330;
+
+    int relativeWidth(int val)
+    {
+        return cast(int)((cast(float)val / _initialWidth) * _position.width);
+    }
+
+    int relativeHeight(int val)
+    {
+        return cast(int)((cast(float)val / _initialHeight) * _position.height);
     }
 }

--- a/examples/distort/gui.d
+++ b/examples/distort/gui.d
@@ -43,7 +43,7 @@ nothrow:
     this(DistortClient client)
     {
         _client = client;
-        super(_initialWidth, _initialHeight); // size
+        super(_initialWidth, _initialHeight, _client); // size
 
 
         // Note: PBRCompositor default lighting might change in a future version (increase of light to allow white plastics).
@@ -161,15 +161,15 @@ nothrow:
     {
         if(isDoubleClick)
         {
-            if(_position.width == _initialHeight * 2)
+            if(_position.width == cast(int)(_initialWidth * 0.5))
             {
-                _client.hostCommand().requestResize(_initialWidth, _initialHeight);
                 resizeWindow(_initialWidth, _initialHeight);
             }
             else
             {
-                _client.hostCommand().requestResize(_initialWidth * 2, _initialHeight * 2);
-                resizeWindow(_initialWidth * 2, _initialHeight * 2);
+                int newWidth = cast(int)(_initialWidth * 0.5);
+                int newHeight = cast(int)(_initialHeight * 0.5);
+                resizeWindow(newWidth, newHeight);
             }
             return true;
         }

--- a/examples/distort/gui.d
+++ b/examples/distort/gui.d
@@ -163,11 +163,11 @@ nothrow:
         {
             if(_position.width == _initialHeight * 2)
             {
-                _client.hostCommand().requestResize(_initialWidth, _initialHeight);
+                resizeWindow(_initialWidth, _initialHeight);
             }
             else
             {
-                _client.hostCommand().requestResize(_initialWidth * 2, _initialHeight * 2);
+                resizeWindow(_initialWidth * 2, _initialHeight * 2);
             }
             return true;
         }

--- a/flatwidgets/dplug/flatwidgets/flatbackgroundgui.d
+++ b/flatwidgets/dplug/flatwidgets/flatbackgroundgui.d
@@ -19,6 +19,8 @@ import dplug.core.nogc;
 import dplug.gui.graphics;
 import dplug.gui.element;
 
+import dplug.client : Client;
+
 /// FlatBackgroundGUI provides a background that is loaded from a PNG or JPEG
 /// image. The string for backgroundPath should be in "stringImportPaths"
 /// specified in dub.json
@@ -28,9 +30,9 @@ public:
 nothrow:
 @nogc:
 
-    this(int width, int height)
+    this(int width, int height, Client client)
     {
-        super(width, height, flagRaw);
+        super(width, height, flagRaw, client);
         _backgroundImage = loadOwnedImage(cast(ubyte[])(import(backgroundPath)));
     }
     

--- a/flatwidgets/dplug/flatwidgets/flatbackgroundgui.d
+++ b/flatwidgets/dplug/flatwidgets/flatbackgroundgui.d
@@ -42,77 +42,32 @@ nothrow:
     
     override void reflow(box2i availableSpace)
     {
+        bool reallocResizedImage = availableSpace.width != _position.width || availableSpace.height != _position.height;
+        
         // Note: the position is entirely decorrelated from the size of _backgroundImage
-        // IMPORTANT technically we don't need to take all space, since we'll never draw outside a subrect
-        //           this is for the future where we may resize the image.
         _position = availableSpace;
 
-        // Compute which rect of _backgroundImage goes into which rect of _position
-        // if the full element was entirely dirty
-        // The image is not resized to fit, instead it is cropped.
-        int sourceX;
-        int sourceY;
-        int destX;
-        int destY;
-        int width;
-        int height;
-        if (_position.width >= _backgroundImage.w)
+        
+        if(reallocResizedImage)
         {
-            width = _backgroundImage.w;
-            sourceX = 0;
-            destX = 0;
+            _backgroundImageResized = mallocNew!(OwnedImage!RGBA)(_position.width, _position.height);
+            resizeBilinear(_backgroundImage.toRef(), _backgroundImageResized.toRef());
+            setDirtyWhole();
         }
-        else
-        {
-            width = _position.width;
-            sourceX = 0;
-            destX = 0;
-        }
-
-        if (_position.height >= _backgroundImage.h)
-        {
-            height = _backgroundImage.h;
-            sourceY = 0;
-            destY = 0;
-        }
-        else
-        {
-            height = _position.height;
-            sourceY = 0;
-            destY = 0;
-        }
-
-        _sourceRect = box2i.rectangle(sourceX, sourceY, width, height);
-        _destRect = box2i.rectangle(destX, destY, width, height);
-        _offset = vec2i(destX - sourceX, destY - sourceY);
     }
     
     override void onDrawRaw(ImageRef!RGBA rawMap, box2i[] dirtyRects)
     {
-        auto backgroundRef = _backgroundImage.toRef();
+        auto backgroundRef = _backgroundImageResized.toRef();
 
         foreach(dirtyRect; dirtyRects)
         {
-            // Compute source and dest
-            box2i source = _sourceRect.intersection(dirtyRect.translate(_offset));
-            box2i dest = _destRect.intersection(dirtyRect); // since dirtyRect is relative to _position 
-            if (source.empty())
-                continue;
-            if (dest.empty())
-                continue;
+            int W = dirtyRect.width;
+            int H = dirtyRect.height;
 
-            assert(source.width == dest.width);
-            assert(source.height == dest.height);
+            auto croppedRawIn = backgroundRef.cropImageRef(dirtyRect);
+            auto croppedRawOut = rawMap.cropImageRef(dirtyRect);
             
-            int W = dest.width;
-            int H = dest.height;
-
-            auto croppedRawIn = backgroundRef.cropImageRef(source);
-            auto croppedRawOut = rawMap.cropImageRef(dest);
-
-            immutable RGBA inputMaterial = RGBA(0, 0, 0, 0);
-            immutable L16 inputDepth = L16(0);
-
             for(int j = 0; j < H; ++j)
             {
                 RGBA[] inputRaw = croppedRawIn.scanline(j);
@@ -128,13 +83,5 @@ nothrow:
     
 private:
     OwnedImage!RGBA _backgroundImage;
-
-    /// Where pixel data is taken in the image, expressed in _background coordinates.
-    box2i _sourceRect;
-
-    /// Where it is deposited. Same size than _sourceRect. Expressed in _position coordinates.
-    box2i _destRect;
-
-    /// Offset from source to dest.
-    vec2i _offset;
+    OwnedImage!RGBA _backgroundImageResized;
 }

--- a/flatwidgets/dplug/flatwidgets/flatslider.d
+++ b/flatwidgets/dplug/flatwidgets/flatslider.d
@@ -51,6 +51,15 @@ nothrow:
         return _sensivity = sensivity;
     }
 
+    override void reflow(box2i availableSpace)
+    {
+        _position = availableSpace;
+
+        _filmstripScaled = mallocNew!(OwnedImage!RGBA)(cast(int)(_position.width), cast(int)(_position.height * _numFrames));
+        resizeBilinear(_filmstrip.toRef(), _filmstripScaled.toRef());
+    }
+
+
     // TODO: it doesn't seem the animation is used when drawing
     override void onAnimate(double dt, double time) nothrow @nogc
     {
@@ -66,7 +75,7 @@ nothrow:
     override void onDrawRaw(ImageRef!RGBA rawMap, box2i[] dirtyRects)
     {
         setCurrentImage();
-        auto _currentImage = _filmstrip.crop(box2i(_imageX1, _imageY1, _imageX2, _imageY2));
+        auto _currentImage = _filmstripScaled.crop(box2i(_imageX1, _imageY1, _imageX2, _imageY2));
         foreach(dirtyRect; dirtyRects)
         {
             auto croppedRawIn = _currentImage.crop(dirtyRect);
@@ -101,10 +110,10 @@ nothrow:
         if(currentFrame > 59) currentFrame = 59;
 
         _imageX1 = 0;
-        _imageY1 = (_filmstrip.h / _numFrames) * currentFrame;
+        _imageY1 = (_filmstripScaled.h / _numFrames) * currentFrame;
 
-        _imageX2 = _filmstrip.w;
-        _imageY2 = _imageY1 + (_filmstrip.h / _numFrames);
+        _imageX2 = _filmstripScaled.w;
+        _imageY2 = _imageY1 + (_filmstripScaled.h / _numFrames);
 
     }
 
@@ -229,6 +238,7 @@ protected:
     Parameter _param;
 
     OwnedImage!RGBA _filmstrip;
+    OwnedImage!RGBA _filmstripScaled;
     int _numFrames;
     int _imageX1, _imageX2, _imageY1, _imageY2;
     int currentFrame;

--- a/gui/dplug/gui/graphics.d
+++ b/gui/dplug/gui/graphics.d
@@ -314,6 +314,12 @@ nothrow:
         _updateMargin = margin;
     }
 
+    void resizeWindow(int width, int height) nothrow @nogc
+    {
+        _window.resize(width, height);
+        // _client.hostCommand().requestResize(_initialWidth * 2, _initialHeight * 2);
+    }
+
 protected:
 
     UIContext _uiContext;

--- a/gui/dplug/gui/graphics.d
+++ b/gui/dplug/gui/graphics.d
@@ -317,7 +317,6 @@ nothrow:
     void resizeWindow(int width, int height) nothrow @nogc
     {
         _window.resize(width, height);
-        // _client.hostCommand().requestResize(_initialWidth * 2, _initialHeight * 2);
     }
 
 protected:

--- a/gui/dplug/gui/graphics.d
+++ b/gui/dplug/gui/graphics.d
@@ -73,9 +73,10 @@ nothrow:
         return compositor;
     }
 
-    this(int initialWidth, int initialHeight, UIFlags flags)
+    this(int initialWidth, int initialHeight, UIFlags flags, Client client)
     {
         _uiContext = mallocNew!UIContext();
+        _client = client;
         super(_uiContext, flags);
 
         _windowListener = mallocNew!WindowListener(this);
@@ -316,12 +317,15 @@ nothrow:
 
     void resizeWindow(int width, int height) nothrow @nogc
     {
+        _client.hostCommand().requestResize(width, height);
         _window.resize(width, height);
     }
 
 protected:
 
     UIContext _uiContext;
+
+    Client _client;
 
     WindowListener _windowListener;
 

--- a/lv2/dplug/lv2/lv2_init.d
+++ b/lv2/dplug/lv2/lv2_init.d
@@ -23,6 +23,7 @@
 module dplug.lv2.lv2_init;
 
 import core.stdc.stdint;
+import core.stdc.string;
 
 import dplug.core.nogc;
 import dplug.core.runtime;
@@ -167,7 +168,7 @@ void build_all_lv2_descriptors(ClientClass)() nothrow @nogc
             instantiate:    &instantiateUI,
             cleanup:        &cleanupUI,
             port_event:     &port_eventUI,
-            extension_data: null// &extension_dataUI TODO support it for real
+            extension_data: &extensionDataUI
         };
         lv2UIDescriptor = descriptor;
     }
@@ -314,10 +315,28 @@ extern(C) nothrow @nogc
         debug(debugLV2Client) debugLog("<port_event");
     }
 
-    const (void)* extension_dataUI(const char* uri)
+    const (void)* extensionDataUI(const char* uri)
     {
+        void* feature = null;
         debug(debugLV2Client) debugLog(">extension_dataUI");
+        static const LV2UI_Resize lv2UIResize = LV2UI_Resize(cast(void*)null, &uiResize);
+        if (!strcmp(uri, LV2_UI__resize)) {
+            feature = cast(void*)&lv2UIResize;
+        }
         debug(debugLV2Client) debugLog("<extension_dataUI");
-        return null;
+        return feature;
+    }
+
+    /// This is currently not fully implemented
+    /// According to the LV2 IRC channel, this extension is planned to be
+    /// deprecated.  The only known host that uses this extension is
+    /// synthpod.  LV2 plug-ins should respond directly to resize
+    /// events from the window.
+    int uiResize(LV2UI_Feature_Handle handle, int width, int height)
+    {
+        ScopedForeignCallback!(false, true) scopedCallback;
+        scopedCallback.enter();
+        LV2Client lv2client = cast(LV2Client)handle;
+        return 0;
     }
 }

--- a/lv2/dplug/lv2/lv2client.d
+++ b/lv2/dplug/lv2/lv2client.d
@@ -362,7 +362,7 @@ nothrow:
         int transientWinId;
         void* parentId = null;
         LV2_Options_Option* options = null;
-        LV2UI_Resize* uiResize = null;
+        _uiResize = null;
         LV2_URID_Map* uridMap = null;
 
         // Useful to record automation
@@ -375,7 +375,7 @@ nothrow:
             if (strcmp(features[i].URI, LV2_UI__parent) == 0)
                 parentId = cast(void*)features[i].data;
             else if (strcmp(features[i].URI, LV2_UI__resize) == 0)
-                uiResize = cast(LV2UI_Resize*)features[i].data;
+                _uiResize = cast(LV2UI_Resize*)features[i].data;
             else if (strcmp(features[i].URI, LV2_OPTIONS__options) == 0)
                 options = cast(LV2_Options_Option*)features[i].data;
             else if (strcmp(features[i].URI, LV2_URID__map) == 0)
@@ -407,7 +407,7 @@ nothrow:
             if (_client.getGUISize(&width, &height))
             {
                 _graphicsMutex.lock();
-                uiResize.ui_resize(uiResize.handle, width, height);
+                _uiResize.ui_resize(_uiResize.handle, width, height);
                 _graphicsMutex.unlock();
             }
 
@@ -459,7 +459,8 @@ nothrow:
 
     override bool requestResize(int width, int height)
     {
-        return false;
+        int result = _uiResize.ui_resize(_uiResize.handle, width, height);
+        return result == 0;
     }
 
     // Not properly implemented yet. LV2 should have an extension to get DAW information.
@@ -515,6 +516,7 @@ private:
     LV2UI_Write_Function _write_function;
     LV2UI_Controller _controller;
     LV2UI_Touch* _uiTouch;
+    LV2UI_Resize* _uiResize;
 
     // Current time info, eventually extrapolated when data is missing.
     TimeInfo _currentTimeInfo;

--- a/pbrwidgets/dplug/pbrwidgets/pbrbackgroundgui.d
+++ b/pbrwidgets/dplug/pbrwidgets/pbrbackgroundgui.d
@@ -23,6 +23,8 @@ import dplug.gui.element;
 import dplug.gui.compositor;
 import dplug.gui.legacypbr;
 
+import dplug.client: Client;
+
 /// PBRBackgroundGUI provides a PBR background loaded from PNG or JPEG images.
 /// It's very practical while in development because it let's you reload the six
 /// images used with the press of ENTER.
@@ -40,9 +42,9 @@ public:
 nothrow:
 @nogc:
 
-    this(int width, int height)
+    this(int width, int height, Client client)
     {
-        super(width, height, flagPBR);
+        super(width, height, flagPBR, client);
         auto basecolorData = cast(ubyte[])(import(baseColorPath));
         auto emissiveData = cast(ubyte[])(import(emissivePath));        
         auto materialData = cast(ubyte[])(import(materialPath));

--- a/vst3/dplug/vst3/client.d
+++ b/vst3/dplug/vst3/client.d
@@ -44,6 +44,8 @@ public:
 nothrow:
 @nogc:
 
+    DplugView* _dplugView;
+
     this(Client client)
     {
         debug(logVST3Client) debugLog(">VST3Client.this()");
@@ -1263,6 +1265,7 @@ nothrow:
     this(VST3Client vst3Client)
     {
         _vst3Client = vst3Client;
+        _vst3Client._dplugView = this.ptr;
         _graphicsMutex = makeMutex();
     }
 
@@ -1428,6 +1431,14 @@ nothrow:
         return kResultTrue;
     }
 
+    void resize(int width, int height)
+    {
+		ViewRect vr;
+		vr.right = width;
+		vr.bottom = height;
+		return _plugFrame.resizeView (this, &vr) == kResultTrue ? true : false;
+    }
+
 private:
     VST3Client _vst3Client;
     UncheckedMutex _graphicsMutex;
@@ -1493,7 +1504,7 @@ nothrow:
     override bool requestResize(int width, int height)
     {
         // FUTURE, will need to keep an instance pointer of the current IPluginView
-        return false;
+        return _vst3Client.dplugView.resize(width, height);
     }
 
     DAW getDAW()

--- a/window/dplug/window/cocoawindow.d
+++ b/window/dplug/window/cocoawindow.d
@@ -182,7 +182,10 @@ public:
 
     override void resize(int width, int height)
     {
-
+        NSSize size = NSSize(cast(CGFloat)width, cast(CGFloat)height);
+        _listener.onResized(width, height);
+        _view.setFrameSize(size);
+        _view.setNeedsDisplay();
     }
 
 private:
@@ -334,12 +337,11 @@ private:
         // Updates internal buffers in case of startup/resize
         // FUTURE: why is the bounds rect too large? It creates havoc in AU even without resizing.
         {
-            /*
             NSRect boundsRect = _view.bounds();
             int width = cast(int)(boundsRect.size.width);   // truncating down the dimensions of bounds
             int height = cast(int)(boundsRect.size.height);
-            */
-            updateSizeIfNeeded(_askedWidth, _askedHeight);
+
+            updateSizeIfNeeded(width, height);
         }
 
         // The first drawRect callback occurs before the timer triggers.

--- a/window/dplug/window/cocoawindow.d
+++ b/window/dplug/window/cocoawindow.d
@@ -180,6 +180,11 @@ public:
             return _view._id;
     }
 
+    override void resize(int width, int height)
+    {
+
+    }
+
 private:
 
     MouseState getMouseState(NSEvent event)

--- a/window/dplug/window/win32window.d
+++ b/window/dplug/window/win32window.d
@@ -38,8 +38,6 @@ import dplug.window.window;
 nothrow:
 @nogc:
 
-__gshared LONG_PTR parentWndProcCallback;
-__gshared Win32Window childWindow;
 
 
 version(Windows)
@@ -213,8 +211,9 @@ version(Windows)
             switch (uMsg)
             {
                 case WM_SIZE:
+                case WM_MOVE:
                 {
-                    int i = 0;
+                    updateSizeIfNeeded();
                     return 0;
                 }
                 case WM_KEYDOWN:
@@ -513,6 +512,11 @@ version(Windows)
             return cast(void*)( cast(size_t)_hwnd );
         }
 
+        void resize(int width, int height)
+        {
+
+        }
+
     private:
         enum TIMER_ID = 144;
 
@@ -570,6 +574,8 @@ version(Windows)
         }
     }
 
+__gshared LONG_PTR parentWndProcCallback;
+__gshared Win32Window childWindow;
 
     extern(Windows) nothrow
     {

--- a/window/dplug/window/window.d
+++ b/window/dplug/window/window.d
@@ -123,6 +123,9 @@ nothrow:
 
     /// Gets the window's OS handle.
     void* systemHandle();
+
+    ///  Resizes the window from the client
+    void resize(int width, int height);
 }
 
 enum WindowPixelFormat


### PR DESCRIPTION
Most of the infrastructure was already in place to support resizable UIs.  The main hurdle was that static resources like background images couldn't be easily resized.  I've added a new function to resize a source `ImageRef` to a destination `ImageRef` using bilinear interpolation.

Existing plug-ins will need to override `void reflow(box2i availableSpace)` in their UIElements and also call `reflow` with the new positions when updating positions in order for the scaling to take place.  Currently this is a breaking change so it will either need to be in Dplug v10 or we will need to find a way to make this an optional feature.

This is still a work in progress but I wanted to go ahead and open it for review and feedback.

Checklist
- [x] Bilinear interpolation for ImageRefs]
- [x] Resizable MipMaps (needed for `UIImageKnob`)
- [x] Convert flat widgets
- [x] Convert PBR widgets
- [x] Canvas compatibility (throws an error in `linear_blit` currently when applying scaling)
- [x] Handle in LV2
- [x] Handle in VST
- [x] Handle in VST3
- [x] Handle in AU
- [x] Handle in Win32 window
- [x] Handle in X11 window
- [x] Handle in Cocoa window