### PR TITLE
Reduction of binary size on Linux platform

### DIFF
--- a/examples/clipit/dub.json
+++ b/examples/clipit/dub.json
@@ -39,25 +39,28 @@
             "name": "VST3",
             "versions": ["VST3"],
             "targetType": "dynamicLibrary",
-            "lflags-osx-ldc": [ "-exported_symbols_list", "module-vst3.lst", "-dead_strip" ]
+            "lflags-osx-ldc": [ "-exported_symbols_list", "module-vst3.lst", "-dead_strip" ],
+            "lflags-linux-ldc": [ "--version-script=module-vst3.ver" ]
         },
         {
             "name": "VST",
             "versions": ["VST"],
             "targetType": "dynamicLibrary",
-            "lflags-osx-ldc": [ "-exported_symbols_list", "module-vst.lst", "-dead_strip" ]
+            "lflags-osx-ldc": [ "-exported_symbols_list", "module-vst.lst", "-dead_strip" ],
+            "lflags-linux-ldc": [ "--version-script=module-vst.ver" ]
         },
         {
             "name": "AU",
             "versions": ["AU"],
             "targetType": "dynamicLibrary",
             "lflags-osx-ldc": [ "-exported_symbols_list", "module-au.lst", "-dead_strip" ]
-        },       
+        },
         {
             "name": "LV2",
             "versions": ["LV2"],
             "targetType": "dynamicLibrary",
-            "lflags-osx-ldc": [ "-exported_symbols_list", "module-lv2.lst", "-dead_strip" ]
+            "lflags-osx-ldc": [ "-exported_symbols_list", "module-lv2.lst", "-dead_strip" ],
+            "lflags-linux-ldc": [ "--version-script=module-lv2.ver" ]
         }
     ]
 }

--- a/examples/clipit/module-lv2.ver
+++ b/examples/clipit/module-lv2.ver
@@ -1,0 +1,4 @@
+LV2ABI_1.0 {
+    global: lv2_descriptor; lv2ui_descriptor; GenerateManifestFromClient;
+    local: *;
+};

--- a/examples/clipit/module-vst.ver
+++ b/examples/clipit/module-vst.ver
@@ -1,0 +1,4 @@
+VSTABI_1.0 {
+    global: VSTPluginMain; main;
+    local: *;
+};

--- a/examples/clipit/module-vst3.ver
+++ b/examples/clipit/module-vst3.ver
@@ -1,0 +1,4 @@
+VST3ABI_1.0 {
+    global: GetPluginFactory; ModuleEntry; ModuleExit;
+    local: *;
+};

--- a/examples/distort/dub.json
+++ b/examples/distort/dub.json
@@ -43,13 +43,15 @@
             "name": "VST3",
             "versions": ["VST3"],
             "targetType": "dynamicLibrary",
-            "lflags-osx-ldc": [ "-exported_symbols_list", "module-vst3.lst", "-dead_strip" ]
+            "lflags-osx-ldc": [ "-exported_symbols_list", "module-vst3.lst", "-dead_strip" ],
+            "lflags-linux-ldc": [ "--version-script=module-vst3.ver" ]
         },
         {
             "name": "VST",
             "versions": ["VST"],
             "targetType": "dynamicLibrary",
-            "lflags-osx-ldc": [ "-exported_symbols_list", "module-vst.lst", "-dead_strip" ]
+            "lflags-osx-ldc": [ "-exported_symbols_list", "module-vst.lst", "-dead_strip" ],
+            "lflags-linux-ldc": [ "--version-script=module-vst.ver" ]
         },
         {
             "name": "AU",
@@ -61,7 +63,8 @@
             "name": "LV2",
             "versions": ["LV2"],
             "targetType": "dynamicLibrary",
-            "lflags-osx-ldc": [ "-exported_symbols_list", "module-lv2.lst", "-dead_strip" ]
+            "lflags-osx-ldc": [ "-exported_symbols_list", "module-lv2.lst", "-dead_strip" ],
+            "lflags-linux-ldc": [ "--version-script=module-lv2.ver" ]
         }
     ]
 }

--- a/examples/distort/module-lv2.ver
+++ b/examples/distort/module-lv2.ver
@@ -1,0 +1,4 @@
+LV2ABI_1.0 {
+    global: lv2_descriptor; lv2ui_descriptor; GenerateManifestFromClient;
+    local: *;
+};

--- a/examples/distort/module-vst.ver
+++ b/examples/distort/module-vst.ver
@@ -1,0 +1,4 @@
+VSTABI_1.0 {
+    global: VSTPluginMain; main;
+    local: *;
+};

--- a/examples/distort/module-vst3.ver
+++ b/examples/distort/module-vst3.ver
@@ -1,0 +1,4 @@
+VST3ABI_1.0 {
+    global: GetPluginFactory; ModuleEntry; ModuleExit;
+    local: *;
+};


### PR DESCRIPTION
#436
Hi, this adds a solution to reduce binary size on Linux.
It's a GNU equivalent of the method already used with the macOS platform.

Reference https://sourceware.org/binutils/docs-2.35/ld/VERSION.html#VERSION

This results in a cleaned symbol list, and leads to a size reduction in the same waters as mentioned in the report (~4x).
```
jpc@ext> nm -D builds/Linux-64b-VST/Witty\ Audio\ CLIP\ It.so | grep -w T 
0000000000032b90 T main@@VSTABI_1.0
0000000000032a80 T VSTPluginMain@@VSTABI_1.0
```

Does the solution look satisfactory?