### PR TITLE
Avoid crashing in Carla when the VST3 has no UI

### DIFF
--- a/vst3/dplug/vst3/client.d
+++ b/vst3/dplug/vst3/client.d
@@ -935,6 +935,8 @@ nothrow:
     {
         debug(logVST3Client) debugLog(">createView".ptr);
         debug(logVST3Client) scope(exit) debugLog("<createView".ptr);
+        if (!_client.hasGUI)
+            return null;
         if (name !is null && strcmp(name, "editor") == 0)
             return mallocNew!DplugView(this);
         return null;


### PR DESCRIPTION
Under the Carla host, the VST3 plugin will have its function `createView` invoked beforehand, to check whether the plugin has an editor.
If the function does not return `null` appropriately, a crash will occur.