### PR TITLE
Latency reporting for LV2

### DIFF
--- a/lv2/dplug/lv2/lv2client.d
+++ b/lv2/dplug/lv2/lv2client.d
@@ -75,6 +75,7 @@ nothrow:
         _client.setHostCommand(this);
         _graphicsMutex = makeMutex();
         _legalIOIndex = legalIOIndex;
+        _latencyOutput = null;
         _eventsInput = null;
     }
 
@@ -168,26 +169,40 @@ nothrow:
     void connect_port(uint32_t port, void* data)
     {
         int numParams = cast(int)(_client.params.length);
-        if(port < _client.params.length)
+        if(port < numParams)
         {
             _paramsPointers[port] = cast(float*)data;
+            return;
         }
-        else if(port < _numInputs + numParams)
+        port -= numParams;
+        if(port < _numInputs)
         {
-            uint input = port - numParams;
-            _inputPointersProvided[input] = cast(float*)data;
+            _inputPointersProvided[port] = cast(float*)data;
+            return;
         }
-        else if(port < _numOutputs + _numInputs + numParams)
+        port -= _numInputs;
+        if(port < _numOutputs)
         {
-            uint output = port - numParams - _numInputs;
-            _outputPointersProvided[output] = cast(float*)data;
+            _outputPointersProvided[port] = cast(float*)data;
+            return;
         }
-        else if(port < 1 + _numOutputs + _numInputs + numParams)
+        port -= _numOutputs;
+        if (_numOutputs > 0)
+        {
+            if (port == 0)
+            {
+                _latencyOutput = cast(float*)data;
+                return;
+            }
+            --port;
+        }
+        if(port == 0)
         {
             _eventsInput = cast(LV2_Atom_Sequence*)data;
+            return;
         }
-        else
-            assert(false, "Error unknown port index");
+        --port;
+        assert(false, "Error unknown port index");
     }
 
     void activate()
@@ -347,6 +362,10 @@ nothrow:
         _client.processAudioFromHost(_inputPointersProcessing, _outputPointersProcessing, n_samples, _currentTimeInfo);
 
         _currentTimeInfo.timeInSamples += n_samples;
+
+        // Report latency to host, expressed in frames
+        if (_latencyOutput)
+            *_latencyOutput = _client.latencySamples(_sampleRate);
     }
 
     void instantiateUI(const LV2UI_Descriptor* descriptor,
@@ -500,6 +519,9 @@ private:
 
     // Output pointers used by processing, recomputed at each run().
     float*[] _outputPointersProcessing;
+
+    // Output pointer for latency reporting, `null` if not provided.
+    float* _latencyOutput;
 
     LV2_Atom_Sequence* _eventsInput;
 

--- a/lv2/dplug/lv2/lv2client.d
+++ b/lv2/dplug/lv2/lv2client.d
@@ -77,6 +77,7 @@ nothrow:
         _legalIOIndex = legalIOIndex;
         _latencyOutput = null;
         _eventsInput = null;
+        _latencySamples = 0;
     }
 
     ~this()
@@ -164,6 +165,9 @@ nothrow:
 
         _currentTimeInfo = TimeInfo.init;
         _currentTimeInfo.hostIsPlaying = true;
+
+        if (_numOutputs > 0)
+            _latencySamples = _client.latencySamples(rate);
     }
 
     void connect_port(uint32_t port, void* data)
@@ -365,7 +369,7 @@ nothrow:
 
         // Report latency to host, expressed in frames
         if (_latencyOutput)
-            *_latencyOutput = _client.latencySamples(_sampleRate);
+            *_latencyOutput = _latencySamples;
     }
 
     void instantiateUI(const LV2UI_Descriptor* descriptor,
@@ -526,6 +530,9 @@ private:
     LV2_Atom_Sequence* _eventsInput;
 
     float _sampleRate;
+
+    // The latency value expressed in frames
+    int _latencySamples;
 
     UncheckedMutex _graphicsMutex;
 

--- a/lv2/dplug/lv2/ttl.d
+++ b/lv2/dplug/lv2/ttl.d
@@ -448,7 +448,14 @@ const(char)[] buildParamPortConfiguration(Parameter[] params, LegalIO legalIO, b
         char[] indexString = cast(char[])malloc(char.sizeof * 256)[0..256];
         sprintf(indexString.ptr, "%d", portIndex);
         char[] inputString = cast(char[])malloc(char.sizeof * 256)[0..256];
-        sprintf(inputString.ptr, "%d", input);
+        static if (false)
+            sprintf(inputString.ptr, "%d", input);
+        else
+        {
+            // kept for backward compatibility; however this breaks if the
+            // number of parameters change in the future.
+            sprintf(inputString.ptr, "%d", cast(int)(input + params.length));
+        }
 
         strcat(paramString.ptr, "    [\n".ptr);
         strcat(paramString.ptr, "        a lv2:AudioPort , lv2:InputPort ;\n".ptr);

--- a/lv2/dplug/lv2/ttl.d
+++ b/lv2/dplug/lv2/ttl.d
@@ -62,6 +62,7 @@ int GenerateManifestFromClient_templated(alias ClientClass)(char[] outputBuffer,
     strcat(manifest.ptr, "@prefix ui:   <http://lv2plug.in/ns/extensions/ui#>.\n".ptr);
     strcat(manifest.ptr, "@prefix pset: <http://lv2plug.in/ns/ext/presets#>.\n".ptr);
     strcat(manifest.ptr, "@prefix opts: <http://lv2plug.in/ns/ext/options#>.\n".ptr);
+    strcat(manifest.ptr, "@prefix pprops: <http://lv2plug.in/ns/ext/port-props#>.\n".ptr);
     strcat(manifest.ptr, "@prefix vendor: ".ptr); // this prefix abbreviate the ttl with our own URL base
     strcat(manifest.ptr, escapeRDF_IRI(uriVendor).ptr);
     strcat(manifest.ptr, ".\n\n".ptr);
@@ -396,6 +397,8 @@ const(char)[] buildParamPortConfiguration(Parameter[] params, LegalIO legalIO, b
     import std.conv: to;
     import std.uni: toLower;
 
+    int portIndex = 0;
+
     const paramStringLen = 10_000;
     char[] paramString = cast(char[])malloc(char.sizeof * paramStringLen)[0..paramStringLen];
     paramString[0] = '\0';
@@ -407,14 +410,16 @@ const(char)[] buildParamPortConfiguration(Parameter[] params, LegalIO legalIO, b
     // We choose to have symbol "output_<n>" for output channel n
 
     strcat(paramString.ptr, "    lv2:port\n".ptr);
-    foreach(index, param; params)
+    foreach(paramIndex, param; params)
     {
+        char[] indexString = cast(char[])malloc(char.sizeof * 256)[0..256];
+        sprintf(indexString.ptr, "%d", portIndex);
         char[] paramSymbol = cast(char[])malloc(char.sizeof * 256)[0..256];
-        sprintf(paramSymbol.ptr, "p%d", cast(int)index);
-        strcat(paramString.ptr, "    [ \n".ptr);
+        sprintf(paramSymbol.ptr, "p%d", cast(int)paramIndex);
+        strcat(paramString.ptr, "    [\n".ptr);
         strcat(paramString.ptr, "        a lv2:InputPort , lv2:ControlPort ;\n".ptr);
         strcat(paramString.ptr, "        lv2:index ".ptr);
-        strcat(paramString.ptr, paramSymbol[1..$].ptr);
+        strcat(paramString.ptr, indexString.ptr);
         strcat(paramString.ptr, " ;\n".ptr);
         strcat(paramString.ptr, "        lv2:symbol \"".ptr);
         strcat(paramString.ptr, paramSymbol.ptr);
@@ -434,24 +439,21 @@ const(char)[] buildParamPortConfiguration(Parameter[] params, LegalIO legalIO, b
         if (!param.isAutomatable) {
             strcat(paramString.ptr, "        lv2:portProperty <http://kxstudio.sf.net/ns/lv2ext/props#NonAutomable> ;\n".ptr);
         }
-        strcat(paramString.ptr, "    ]".ptr);
-        if(index < params.length - 1 || legalIO.numInputChannels > 0 || legalIO.numOutputChannels > 0)
-            strcat(paramString.ptr, " ,\n".ptr);
-        else
-            strcat(paramString.ptr, " . \n".ptr);
+        strcat(paramString.ptr, "    ] ,\n".ptr);
+        ++portIndex;
     }
 
     foreach(input; 0..legalIO.numInputChannels)
     {
-        char[] paramsLengthPlusInput = cast(char[])malloc(char.sizeof * 10)[0..10];
-        snprintf(paramsLengthPlusInput.ptr, 10, "%d", cast(int)(params.length + input));
-        char[] inputString = cast(char[])malloc(char.sizeof * 10)[0..10];
-        snprintf(inputString.ptr, 10, "%d", cast(int)(params.length + input));
+        char[] indexString = cast(char[])malloc(char.sizeof * 256)[0..256];
+        sprintf(indexString.ptr, "%d", portIndex);
+        char[] inputString = cast(char[])malloc(char.sizeof * 256)[0..256];
+        sprintf(inputString.ptr, "%d", input);
 
-        strcat(paramString.ptr, "    [ \n".ptr);
+        strcat(paramString.ptr, "    [\n".ptr);
         strcat(paramString.ptr, "        a lv2:AudioPort , lv2:InputPort ;\n".ptr);
         strcat(paramString.ptr, "        lv2:index ".ptr);
-        strcat(paramString.ptr, paramsLengthPlusInput.ptr);
+        strcat(paramString.ptr, indexString.ptr);
         strcat(paramString.ptr, ";\n".ptr);
         strcat(paramString.ptr, "        lv2:symbol \"input_".ptr);
         strcat(paramString.ptr, inputString.ptr);
@@ -459,21 +461,18 @@ const(char)[] buildParamPortConfiguration(Parameter[] params, LegalIO legalIO, b
         strcat(paramString.ptr, "        lv2:name \"Input".ptr);
         strcat(paramString.ptr, inputString.ptr);
         strcat(paramString.ptr, "\" ;\n".ptr);
-        strcat(paramString.ptr, "    ]".ptr);
-        if(input < legalIO.numInputChannels - 1 || legalIO.numOutputChannels > 0)
-            strcat(paramString.ptr, " , ".ptr);
-        else
-            strcat(paramString.ptr, " . \n".ptr);
+        strcat(paramString.ptr, "    ] ,\n".ptr);
+        ++portIndex;
     }
 
     foreach(output; 0..legalIO.numOutputChannels)
     {
         char[] indexString = cast(char[])malloc(char.sizeof * 256)[0..256];
-        sprintf(indexString.ptr, "%d", cast(int)(params.length + legalIO.numInputChannels + output));
+        sprintf(indexString.ptr, "%d", portIndex);
         char[] outputString = cast(char[])malloc(char.sizeof * 256)[0..256];
         sprintf(outputString.ptr, "%d", output);
-        
-        strcat(paramString.ptr, "    [ \n".ptr);
+
+        strcat(paramString.ptr, "    [\n".ptr);
         strcat(paramString.ptr, "        a lv2:AudioPort , lv2:OutputPort ;\n".ptr);
         strcat(paramString.ptr, "        lv2:index ".ptr);
         strcat(paramString.ptr, indexString.ptr);
@@ -484,14 +483,26 @@ const(char)[] buildParamPortConfiguration(Parameter[] params, LegalIO legalIO, b
         strcat(paramString.ptr, "        lv2:name \"Output".ptr);
         strcat(paramString.ptr, outputString.ptr);
         strcat(paramString.ptr, "\" ;\n".ptr);
-        strcat(paramString.ptr, "    ]".ptr);
-        if(output < legalIO.numOutputChannels - 1 || hasMIDIInput)
-            strcat(paramString.ptr, " , ".ptr);
-        else
-            strcat(paramString.ptr, " . \n".ptr);
+        strcat(paramString.ptr, "    ] ,\n".ptr);
+        if(output == legalIO.numOutputChannels - 1)
+        {
+            ++portIndex;
+            sprintf(indexString.ptr, "%d", portIndex);
+            strcat(paramString.ptr, "    [\n".ptr);
+            strcat(paramString.ptr, "        a lv2:ControlPort , lv2:OutputPort ;\n".ptr);
+            strcat(paramString.ptr, "        lv2:index ".ptr);
+            strcat(paramString.ptr, indexString.ptr);
+            strcat(paramString.ptr, ";\n".ptr);
+            strcat(paramString.ptr, "        lv2:designation lv2:latency ;\n".ptr);
+            strcat(paramString.ptr, "        lv2:symbol \"latency\" ;\n".ptr);
+            strcat(paramString.ptr, "        lv2:name \"Latency\" ;\n".ptr);
+            strcat(paramString.ptr, "        lv2:portProperty lv2:reportsLatency, pprops:notOnGUI ;\n".ptr);
+            strcat(paramString.ptr, "    ] ,\n".ptr);
+        }
+        ++portIndex;
     }
 
-    strcat(paramString.ptr, "    [ \n".ptr);
+    strcat(paramString.ptr, "    [\n".ptr);
     strcat(paramString.ptr, "        a lv2:InputPort, atom:AtomPort ;\n".ptr);
     strcat(paramString.ptr, "        atom:bufferType atom:Sequence ;\n".ptr);
 
@@ -499,7 +510,7 @@ const(char)[] buildParamPortConfiguration(Parameter[] params, LegalIO legalIO, b
         strcat(paramString.ptr, "        atom:supports <http://lv2plug.in/ns/ext/midi#MidiEvent> ;\n".ptr);
 
     char[] indexString = cast(char[])malloc(char.sizeof * 256)[0..256];
-    sprintf(indexString.ptr, "%d", cast(int)(params.length + legalIO.numInputChannels + legalIO.numOutputChannels));
+    sprintf(indexString.ptr, "%d", portIndex);
 
     strcat(paramString.ptr, "        atom:supports <http://lv2plug.in/ns/ext/time#Position> ;\n".ptr);
     strcat(paramString.ptr, "        lv2:designation lv2:control ;\n".ptr);
@@ -509,7 +520,9 @@ const(char)[] buildParamPortConfiguration(Parameter[] params, LegalIO legalIO, b
     strcat(paramString.ptr, "        lv2:symbol \"lv2_events_in\" ;\n".ptr);
     strcat(paramString.ptr, "        lv2:name \"Events Input\"\n".ptr);
     strcat(paramString.ptr, "    ]".ptr);
-    strcat(paramString.ptr, " . \n".ptr);
+    ++portIndex;
+
+    strcat(paramString.ptr, " .\n".ptr);
 
     return paramString;
 }


### PR DESCRIPTION
#469
This adds latency reporting for LV2.
A control port will be added for this special purpose. It does not show on the host UI.
The port is created only if there exists audio output ports.

Observation: under the Ardour host, the experiment consists of 2 identical audio tracks, except one equipped with a Dplug LV2 plugin which delays by `N`.
- the normal track and delayed track are playing in sync
- when the `N` is varied dynamically by parameter, Ardour adjusts dynamically and the playback gets back on its feet after a moment

**Note** given that latency reporting is dynamic, behaviour may differ from other clients.
It's also the case that `latencySamples` is invoked from the `run` thread.

Attached is the source of the plugin for test. Not included in commit because it's kinda useless outside this.
[latency-introducer.tar.gz](https://github.com/AuburnSounds/Dplug/files/5724172/latency-introducer.tar.gz)

Some things to note at LV2 level:
- the simplifies a bit the port numbering gymnastics. This is welcome in case there are optionals which introduce gaps, such as the latency port.
- the LV2 generator has some problems which needed solving; for instance, the outputs were labelled from 0, but inputs were labelled according to their starting port index.
- other problem, in the exporter, a terminating `.` character would be introduced in some conditions for intermediate ports, but it cannot be because there is always a next port (events port is last, and always existing)
