### PR TITLE
Installer for 32-bit and uninstaller

### DIFF
--- a/tools/dplug-build/source/main.d
+++ b/tools/dplug-build/source/main.d
@@ -1391,6 +1391,9 @@ void generateWindowsInstaller(string outputDir,
     {
         bool pluginIsDir = p.pluginDir.isDir;
 
+        if(p.is64b)
+          content ~= "    ${If} ${RunningX64}\n";
+
         if (p.format == "VST")
         {
             string instDirVar = "InstDir" ~ formatSectionIdentifier(p);
@@ -1407,6 +1410,9 @@ void generateWindowsInstaller(string outputDir,
         {
             content ~= format!"    Delete \"%s\\%s\"\n"(p.installDir, p.pluginDir.baseName);
         }
+
+        if(p.is64b)
+          content ~= "    ${EndIf}\n";
     }
     content ~= format!"    DeleteRegKey HKLM \"%s\"\n"(regProductKey);
     content ~= format!"    DeleteRegKey /ifempty HKLM \"%s\"\n"(regVendorKey);

--- a/tools/dplug-build/source/main.d
+++ b/tools/dplug-build/source/main.d
@@ -26,10 +26,11 @@ string MAC_LV2_DIR      = "/Library/Audio/Plug-Ins/LV2";
 
 string WIN_VST3_DIR     = "$PROGRAMFILES64\\Common Files\\VST3";
 string WIN_VST_DIR      = "$PROGRAMFILES64\\VSTPlugins";
-string WIN_LV2_DIR      = "$APPDATA\\LV2";
+string WIN_LV2_DIR      = "$PROGRAMFILES64\\Common Files\\LV2";
 string WIN_AAX_DIR      = "$PROGRAMFILES64\\Common Files\\Avid\\Audio\\Plug-Ins";
 string WIN_VST3_DIR_X86 = "$PROGRAMFILES\\Common Files\\VST3";
 string WIN_VST_DIR_X86  = "$PROGRAMFILES\\VSTPlugins";
+string WIN_LV2_DIR_X86  = "$PROGRAMFILES\\Common Files\\LV2";
 
 
 version(linux)
@@ -749,7 +750,10 @@ int main(string[] args)
                         {
                             format = "LV2";
                             title = "LV2 plugin-in";
-                            installDir = WIN_LV2_DIR;
+                            if (arch == arch.x86_64)
+                                installDir = WIN_LV2_DIR;
+                            else
+                                installDir = WIN_LV2_DIR_X86;
                         }
 
                         windowsPackages ~= WindowsPackage(format, pluginDirectory, title, installDir, sizeInKiloBytes, arch == arch.x86_64);

--- a/tools/dplug-build/source/main.d
+++ b/tools/dplug-build/source/main.d
@@ -1339,14 +1339,12 @@ void generateWindowsInstaller(string outputDir,
             {
                 content ~= "  ${If} ${SectionIsSelected} ${Sec" ~ p.format ~ "}\n";
                 content ~= "    ${AndIfNot} ${RunningX64}\n";
-                content ~= "      SetOutPath $InstDir" ~ formatSectionIdentifier(p) ~ "\n";
                 content ~= "      SetOutPath \"" ~ p.installDir ~ "\"\n";
                 content ~= "      File " ~ (pluginIsDir ? "/r " : "") ~ "\"" ~ p.pluginDir.asNormalizedPath.array ~ "\"\n";
             }
             else
             {
                 content ~= "  ${ElseIf} ${SectionIsSelected} ${Sec" ~ p.format ~ "}\n";
-                content ~= "      SetOutPath $InstDir" ~ formatSectionIdentifier(p) ~ "\n";
                 content ~= "      SetOutPath \"" ~ p.installDir ~ "\"\n";
                 content ~= "      File " ~ (pluginIsDir ? "/r " : "") ~ "\"" ~ p.pluginDir.asNormalizedPath.array ~ "\"\n";
                 content ~= "  ${EndIf}\n";

--- a/tools/dplug-build/source/main.d
+++ b/tools/dplug-build/source/main.d
@@ -1332,7 +1332,9 @@ void generateWindowsInstaller(string outputDir,
     }
 
     content ~= "Section\n";
-    content ~= "SetRegView 64\n";
+    content ~= "  ${If} ${RunningX64}\n";
+    content ~= "    SetRegView 64\n";
+    content ~= "  ${EndIf}\n";
 
     auto lv2Packs = packs.filter!((p) => p.format == "LV2").array();
     foreach(p; packs)
@@ -1390,7 +1392,9 @@ void generateWindowsInstaller(string outputDir,
     // Uninstaller
 
     content ~= "Section \"Uninstall\"\n";
-    content ~= "SetRegView 64\n";
+    content ~= "  ${If} ${RunningX64}\n";
+    content ~= "    SetRegView 64\n";
+    content ~= "  ${EndIf}\n";
     foreach(p; packs)
     {
         bool pluginIsDir = p.pluginDir.isDir;

--- a/tools/dplug-build/source/main.d
+++ b/tools/dplug-build/source/main.d
@@ -1298,6 +1298,13 @@ void generateWindowsInstaller(string outputDir,
             string identifier = formatSectionIdentifier(p);
 
             content ~= "Function defaultInstDir" ~ identifier ~ "\n";
+            if(p.is64b)
+            {
+                // The 64-bit version does not get installed on a 32-bit system, skip asking in this case
+                content ~= "  ${IfNot} ${RunningX64}\n";
+                content ~= "    Abort\n";
+                content ~= "  ${EndIf}\n";
+            }
             content ~= "  ${IfNot} ${SectionIsSelected} ${Sec" ~ p.format ~ "}\n";
             content ~= "    Abort\n";
             content ~= "  ${Else}\n";
@@ -1341,7 +1348,10 @@ void generateWindowsInstaller(string outputDir,
         // For all other formats
         else
         {
+            // Only install the 64-bit package on 64-bit OS
             content ~= "  ${If} ${SectionIsSelected} ${Sec" ~ p.format ~ "}\n";
+            if(p.is64b)
+                content ~= "    ${AndIf} ${RunningX64}\n";
             if (p.format == "VST")
                 content ~= "    SetOutPath $InstDir" ~ formatSectionIdentifier(p) ~ "\n";
             else


### PR DESCRIPTION
This work implements new features in the Windows installer
- skip installing any 64-bit software when the operating system is 32-bit
- create the uninstaller
- install LV2 in the global location instead of user

This provides the uninstaller under 32-bit program files in a subfolder named after "vendor/product".

The use of glob `*.*` was replaced with the plugin name.
It's because for doing the uninstaller, we need to be able to specify the name.

When the uninstaller runs, it does not check installed features, it removes all.
Not only being simpler, this ensures that everything deletes even in case partial installs are made one after another.

The VST installation paths, distinct for 32 and 64 bit, are stored in HKLM registry.