### PR TITLE
sysconf is a Posix utility

### DIFF
--- a/core/dplug/core/thread.d
+++ b/core/dplug/core/thread.d
@@ -348,11 +348,6 @@ int getTotalNumberOfCPUs() nothrow @nogc
             procs = 1;
         return procs;
     }
-    else version(linux)
-    {
-        import core.sys.posix.unistd : _SC_NPROCESSORS_ONLN, sysconf;
-        return cast(int) sysconf(_SC_NPROCESSORS_ONLN);
-    }
     else version(Darwin)
     {
         auto nameStr = "machdep.cpu.core_count\0".ptr;
@@ -360,6 +355,11 @@ int getTotalNumberOfCPUs() nothrow @nogc
         size_t len = uint.sizeof;
         sysctlbyname(nameStr, &ans, &len, null, 0);
         return cast(int)ans;
+    }
+    else version(Posix)
+    {
+        import core.sys.posix.unistd : _SC_NPROCESSORS_ONLN, sysconf;
+        return cast(int) sysconf(_SC_NPROCESSORS_ONLN);
     }
     else
         static assert(false, "OS unsupported");


### PR DESCRIPTION
It is defined in POSIX.1 and first appeared in 4.4BSD. While it is true that _SC_NPROCESSORS_ONLN is an extension, many systems provide it.
As such, it should not be marked version(linux). It should be marked version(Posix).
Unbreaks the build on non-Linux systems (OpenBSD, in my case).