### PR TITLE
Make license and signing optional on Windows

### DIFF
--- a/tools/dplug-build/source/main.d
+++ b/tools/dplug-build/source/main.d
@@ -1318,8 +1318,11 @@ void generateWindowsInstaller(string outputDir,
         content ~= "!define MUI_ICON \"" ~ escapeNSISPath(plugin.iconPathWindows) ~ "\"\n";
 
     // Use the markdown licence file with macro expanded.
-    string licensePath = outputDir ~ "/license-expanded.md"; 
-    content ~= "!insertmacro MUI_PAGE_LICENSE \"" ~ licensePath ~ "\"\n";
+    if (plugin.licensePath)
+    {
+        string licensePath = outputDir ~ "/license-expanded.md";
+        content ~= "!insertmacro MUI_PAGE_LICENSE \"" ~ licensePath ~ "\"\n";
+    }
 
     content ~= "!insertmacro MUI_PAGE_COMPONENTS\n";
     content ~= "!insertmacro MUI_LANGUAGE \"English\"\n\n";
@@ -1477,19 +1480,22 @@ void generateWindowsInstaller(string outputDir,
     string makeNsiCommand = format("makensis.exe /V1 %s", nsisPath);
     safeCommand(makeNsiCommand);
 
-    try
+    if (plugin.hasKeyFileWindows)
     {
-        // use windows signtool to sign the installer for distribution
-        string cmd = format("signtool sign /f %s /p %s /tr http://timestamp.sectigo.com /td sha256 /fd sha256 /q %s",
-                            plugin.getKeyFileWindows(),
-                            plugin.getKeyPasswordWindows(),
-                            escapeShellArgument(outExePath));
-        safeCommand(cmd);
-        cwriteln("    =&gt; OK".lgreen);
-    }
-    catch(Exception e)
-    {
-        error(format("Installer signature failed! %s", e.msg));
+        try
+        {
+            // use windows signtool to sign the installer for distribution
+            string cmd = format("signtool sign /f %s /p %s /tr http://timestamp.sectigo.com /td sha256 /fd sha256 /q %s",
+                                plugin.getKeyFileWindows(),
+                                plugin.getKeyPasswordWindows(),
+                                escapeShellArgument(outExePath));
+            safeCommand(cmd);
+            cwriteln("    =&gt; OK".lgreen);
+        }
+        catch(Exception e)
+        {
+            error(format("Installer signature failed! %s", e.msg));
+        }
     }
 }
 

--- a/tools/dplug-build/source/main.d
+++ b/tools/dplug-build/source/main.d
@@ -1480,7 +1480,11 @@ void generateWindowsInstaller(string outputDir,
     string makeNsiCommand = format("makensis.exe /V1 %s", nsisPath);
     safeCommand(makeNsiCommand);
 
-    if (plugin.hasKeyFileWindows)
+    if (!plugin.hasKeyFileWindows)
+    {
+        warning(`Do not distribute unsigned installers! refer to the Dplug installer guide`);
+    }
+    else
     {
         try
         {

--- a/tools/dplug-build/source/plugin.d
+++ b/tools/dplug-build/source/plugin.d
@@ -443,6 +443,11 @@ struct Plugin
         return format("%s%s-%s.exe", sanitizeFilenameString(pluginName), verName, publicVersionString);
     }
 
+    bool hasKeyFileWindows()
+    {
+        return !(keyFileWindows is null);
+    }
+
     string getKeyFileWindows()
     {
         if (keyFileWindows is null)


### PR DESCRIPTION
Only do these steps if relevant info is present in `plugin.json`.
It permits to build installers of the examples.