### PR TITLE
Add dplug-build in subPackages

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -289,6 +289,7 @@
             "dependencies": {
                 "dplug:core": "*"
             }
-        }
+        },
+        "./tools/dplug-build"
     ]
 }


### PR DESCRIPTION
For convenience, I'd like to fetch and run dplug-build without manual git-clone and build (e.g. https://github.com/AuburnSounds/Dplug/wiki/Getting-Started#the-basics) by one command:

```shell
$ dub run dplug:dplug-build@13.3.0 -- -c VST3 --final
```

However, it is impossible because it is not registered in Dplug/dub.json. 

```shell
$ dub run dplug:dplug-build
Package 'dplug:dplug-build' was not found locally but is available online:
---
Description: A library for crafting native audio plugins as simply as possible.
Version: 13.3.0
---
Do you want to fetch 'dplug:dplug-build' now? [Y/n]: 
Fetching dplug:dplug-build 13.3.0...
Failed to find a package named 'dplug:dplug-build' locally.
```

According to https://dub.pm/package-format-json.html#sub-packages, the root dub.json can register packages in sub dirs. And I confirmed it works by these commands:

```shell
$ dub fetch dplug:dplug-build --cache=local
Fetching dplug:dplug-build 13.3.0...
Please note that you need to use `dub run <pkgname>` or add it to dependencies of your package to actually use/run it. dub does not do actual installation of packages outside of its own ecosystem.

$ cd examples/clipit

$ dub run dplug:dplug-build --cache=local  
Package 'dplug:dplug-build' was not found locally but is available online:
---
Description: A library for crafting native audio plugins as simply as possible.
Version: 13.3.0
---
Do you want to fetch 'dplug:dplug-build' now? [Y/n]: 
Fetching dplug:dplug-build 13.3.0...
Building package dplug:dplug-build in /home/klknn/repos/Dplug/tools/dplug-build/
Performing "debug" build using /home/klknn/dlang/ldc-1.30.0/bin/ldc2 for x86_64.
arsd-official:characterencodings 10.8.4: target for configuration "library" is up to date.
arsd-official:dom 10.8.4: target for configuration "library" is up to date.
commonmark-d 1.0.8: target for configuration "library" is up to date.
console-colors 1.0.7: target for configuration "library" is up to date.
intel-intrinsics 1.10.2: target for configuration "library" is up to date.
dplug:core 13.3.0+commit.4.g62c4fd8f: target for configuration "library" is up to date.
dplug:client 13.3.0+commit.4.g62c4fd8f: target for configuration "library" is up to date.
dplug:dplug-build 13.3.0+commit.4.g62c4fd8f: target for configuration "application" is up to date.
To force a rebuild of up-to-date targets, run again with --force.
Running ../../tools/dplug-build/dplug_dplug-build 
info: Missing "licensePath" in plugin.json (eg: "license.txt")
info: Missing "iconPath-windows" in plugin.json (eg: "gfx/myIcon.ico")
info: Missing "iconPath-osx" in plugin.json (eg: "gfx/myIcon.png")

=> Bundling plug-in CLIP It from Witty Audio, archs 64-bit
   configurations: ["VST3"], build type debug, compiler ldc2

*** Building configuration VST3 with ldc2, x86_64 arch...
$ dub build --build=debug --arch=x86_64 --compiler=ldc2 --config=VST3
Performing "debug" build using ldc2 for x86_64.
intel-intrinsics 1.10.5: building configuration "library"...
dplug:core 13.3.0+commit.4.g62c4fd8f: building configuration "library"...
dplug:client 13.3.0+commit.4.g62c4fd8f: building configuration "library"...
dplug:macos 13.3.0+commit.4.g62c4fd8f: building configuration "library"...
dplug:au 13.3.0+commit.4.g62c4fd8f: building configuration "library"...
dplug:math 13.3.0+commit.4.g62c4fd8f: building configuration "library"...
dplug:graphics 13.3.0+commit.4.g62c4fd8f: building configuration "library"...
dplug:canvas 13.3.0+commit.4.g62c4fd8f: building configuration "library"...
dplug:dsp 13.3.0+commit.4.g62c4fd8f: building configuration "library"...
dplug:x11 13.3.0+commit.4.g62c4fd8f: building configuration "library"...
dplug:window 13.3.0+commit.4.g62c4fd8f: building configuration "library"...
dplug:gui 13.3.0+commit.4.g62c4fd8f: building configuration "library"...
dplug:flat-widgets 13.3.0+commit.4.g62c4fd8f: building configuration "library"...
dplug:lv2 13.3.0+commit.4.g62c4fd8f: building configuration "library"...
dplug:vst2 13.3.0+commit.4.g62c4fd8f: building configuration "library"...
dplug:vst3 13.3.0+commit.4.g62c4fd8f: building configuration "library"...
clipit ~master: building configuration "VST3"...
Linking...
    => Build OK, binary size = 7.9 mb, available in ./builds/Linux-64b-VST3

```