### PR TITLE
Update vst sdk url in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
     - name: Setup VST2_SDK
       if: contains(env.SETUP_VST2_SDK, 'true') && steps.dplug-cache.outputs.cache-hit != 'true'
       run: |
-        curl -LOJ https://www.steinberg.net/sdk_downloads/vstsdk366_27_06_2016_build_61.zip
+        curl -LOJ https://web.archive.org/web/20200502121517if_/https://www.steinberg.net/sdk_downloads/vstsdk366_27_06_2016_build_61.zip
         7z x ./vstsdk366_27_06_2016_build_61.zip
         mkdir -p ${{ env.VST2_SDK }}/pluginterfaces/vst2.x
         cp "./VST3 SDK/pluginterfaces/vst2.x/aeffect.h" ${{ env.VST2_SDK }}/pluginterfaces/vst2.x/aeffect.h


### PR DESCRIPTION
The previous VST SDK URL at steinberg seems to be unavailable since the recent LDC 1.32.0 breakage (https://github.com/ldc-developers/ldc/issues/4347) wiped its cache on CI failure. How about using this one at web.archive.org?