### PR TITLE
Fix purity of wave generators

### DIFF
--- a/core/dplug/core/math.d
+++ b/core/dplug/core/math.d
@@ -251,19 +251,19 @@ unittest
 }
 
 /// Quick and dirty sawtooth for testing purposes.
-T rawSawtooth(T)(T x) pure nothrow @nogc
+T rawSawtooth(T)(T x) nothrow @nogc
 {
     return normalizePhase(x) / (cast(T)PI);
 }
 
 /// Quick and dirty triangle for testing purposes.
-T rawTriangle(T)(T x) pure nothrow @nogc
+T rawTriangle(T)(T x) nothrow @nogc
 {
     return 1 - normalizePhase(x) / cast(T)PI_2;
 }
 
 /// Quick and dirty square for testing purposes.
-T rawSquare(T)(T x) pure nothrow @nogc
+T rawSquare(T)(T x) nothrow @nogc
 {
     return normalizePhase(x) > 0 ? 1 : -1;
 }


### PR DESCRIPTION
`rawSawtooth`, `rawTriangle` and `rawSquare` was marked as pure even though they call an impure function that later D compilers will refuse to compile, I've removed the pure attribute from them and that works with the latest LDC on macOS.